### PR TITLE
Add tilde alias

### DIFF
--- a/src/components/amazonLoginModal/index.ts
+++ b/src/components/amazonLoginModal/index.ts
@@ -7,7 +7,7 @@ import {
 import { StringDecoder } from 'string_decoder';
 import { get } from 'svelte/store';
 
-import { settingsStore } from '../../store';
+import { settingsStore } from '~/store';
 
 const { BrowserWindow: RemoteBrowserWindow } = remote;
 

--- a/src/components/amazonLogoutModal/index.ts
+++ b/src/components/amazonLogoutModal/index.ts
@@ -1,6 +1,6 @@
 import { remote } from 'electron';
 
-import { settingsStore } from '../../store';
+import { settingsStore } from '~/store';
 
 const { BrowserWindow } = remote;
 

--- a/src/components/statusBar/StatusBar.svelte
+++ b/src/components/statusBar/StatusBar.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { Jumper } from 'svelte-loading-spinners';
-  import CircleTick from '../../assets/circleTick.svg';
-  import CircleExclamation from '../../assets/circleExclamation.svg';
 
-  import { statusBarStore, settingsStore } from '../../store';
+  import CircleTick from '~/assets/circleTick.svg';
+  import CircleExclamation from '~/assets/circleExclamation.svg';
+  import { statusBarStore, settingsStore } from '~/store';
 </script>
 
 <div class="kp-statusbar--wrapper">

--- a/src/components/syncModal/SyncModalContent.svelte
+++ b/src/components/syncModal/SyncModalContent.svelte
@@ -4,8 +4,8 @@
   import FirstTimeView from './views/FirstTimeView.svelte';
   import SyncButtons from './views/SyncButtons.svelte';
 
-  import { settingsStore } from '../../store';
-  import type { SyncMode } from '../../models';
+  import { settingsStore } from '~/store';
+  import type { SyncMode } from '~/models';
   import type { SyncModalState } from './index';
 
   export let modalState: SyncModalState;

--- a/src/components/syncModal/index.ts
+++ b/src/components/syncModal/index.ts
@@ -1,9 +1,9 @@
 import { App, Modal } from 'obsidian';
 import { get } from 'svelte/store';
 
-import { settingsStore, syncSessionStore } from '../../store';
 import SyncModalContent from './SyncModalContent.svelte';
-import type { SyncMode } from '../../models';
+import { settingsStore, syncSessionStore } from '~/store';
+import type { SyncMode } from '~/models';
 
 export type SyncModalState =
   | 'first-time'

--- a/src/components/syncModal/views/FirstTimeView.svelte
+++ b/src/components/syncModal/views/FirstTimeView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import SyncButtons from './SyncButtons.svelte';
-  import type { SyncMode } from '../../../models';
+  import type { SyncMode } from '~/models';
 
   export let lastSyncMode: SyncMode;
   export let onClick: (mode: SyncMode) => void;

--- a/src/components/syncModal/views/SyncButtons.svelte
+++ b/src/components/syncModal/views/SyncButtons.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import type { SyncMode } from '../../../models';
-  import amazonIcon from '../../../assets/amazonIcon.svg';
-  import clippingsIcon from '../../../assets/clippingsIcon.svg';
+  import type { SyncMode } from '~/models';
+  import amazonIcon from '~/assets/amazonIcon.svg';
+  import clippingsIcon from '~/assets/clippingsIcon.svg';
 
   export let lastSyncMode: SyncMode;
   export let onClick: (mode: SyncMode) => void;

--- a/src/components/syncModal/views/SyncingView.svelte
+++ b/src/components/syncModal/views/SyncingView.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { Jumper } from 'svelte-loading-spinners';
 
-  import { santizeTitleExcess } from '../../../utils';
-  import { syncSessionStore } from '../../../store';
+  import { santizeTitleExcess } from '~/utils';
+  import { syncSessionStore } from '~/store';
 
   let progressMessage: string;
 

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -1,9 +1,9 @@
 import type { Vault } from 'obsidian';
 import { get } from 'svelte/store';
 
-import { settingsStore } from './store';
-import { santizeTitle } from './utils';
-import type { Book } from './models';
+import { settingsStore } from '~/store';
+import { santizeTitle } from '~/utils';
+import type { Book } from '~/models';
 
 const bookFilePath = (book: Book): string => {
   const fileName = santizeTitle(book.title);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { Plugin, addIcon } from 'obsidian';
 import { get } from 'svelte/store';
 
-import FileManager from './fileManager';
-import SyncModal from './components/syncModal';
-import { SettingsTab } from './settingsTab';
-import { StatusBar } from './components/statusBar';
-import { initialise, settingsStore } from './store';
-import { SyncAmazon, SyncClippings } from './sync';
-import kindleIcon from './assets/kindleIcon.svg';
+import FileManager from '~/fileManager';
+import SyncModal from '~/components/syncModal';
+import { SettingsTab } from '~/settingsTab';
+import { StatusBar } from '~/components/statusBar';
+import { initialise, settingsStore } from '~/store';
+import { SyncAmazon, SyncClippings } from '~/sync';
+import kindleIcon from '~/assets/kindleIcon.svg';
 
 addIcon('kindle', kindleIcon);
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,8 +1,8 @@
 import nunjucks from 'nunjucks';
 import { get } from 'svelte/store';
 
-import { settingsStore } from './store';
-import type { BookHighlight, RenderTemplate } from './models';
+import { settingsStore } from '~/store';
+import type { BookHighlight, RenderTemplate } from '~/models';
 
 export class Renderer {
   constructor() {

--- a/src/scraper/scrapeBookHighlights.ts
+++ b/src/scraper/scrapeBookHighlights.ts
@@ -1,6 +1,6 @@
 import type { Root } from 'cheerio';
 
-import type { Book, Highlight } from '../models';
+import type { Book, Highlight } from '~/models';
 import { loadRemoteDom } from './loadRemoteDom';
 
 const mapTextToColor = (colorText: string): Highlight['color'] => {

--- a/src/scraper/scrapeBookMetadata.ts
+++ b/src/scraper/scrapeBookMetadata.ts
@@ -1,6 +1,6 @@
 import type { Root } from 'cheerio';
 
-import type { Book, BookMetadata } from '../models';
+import type { Book, BookMetadata } from '~/models';
 import { loadRemoteDom } from './loadRemoteDom';
 
 const parseDetailsList = ($: Root): Omit<BookMetadata, 'authorUrl'> => {

--- a/src/scraper/scrapeBooks.ts
+++ b/src/scraper/scrapeBooks.ts
@@ -1,6 +1,6 @@
 import type { Root } from 'cheerio';
 
-import type { Book } from '../models';
+import type { Book } from '~/models';
 import { loadRemoteDom } from './loadRemoteDom';
 
 export const parseBooks = ($: Root): Book[] => {

--- a/src/settingsTab/index.ts
+++ b/src/settingsTab/index.ts
@@ -2,12 +2,12 @@ import pickBy from 'lodash.pickby';
 import { App, PluginSettingTab, Setting } from 'obsidian';
 import { get } from 'svelte/store';
 
-import AmazonLogoutModal from '../components/amazonLogoutModal';
+import AmazonLogoutModal from '~/components/amazonLogoutModal';
 import templateInstructions from './templateInstructions.html';
-import type KindlePlugin from '..';
-import { Renderer } from '../renderer';
-import { settingsStore } from '../store';
-import { scrapeLogoutUrl } from '../scraper';
+import type KindlePlugin from '~/.';
+import { Renderer } from '~/renderer';
+import { settingsStore } from '~/store';
+import { scrapeLogoutUrl } from '~/scraper';
 
 const { moment } = window;
 

--- a/src/store/initialise.ts
+++ b/src/store/initialise.ts
@@ -1,4 +1,4 @@
-import type KindlePlugin from '../index';
+import type KindlePlugin from '~/.';
 import { settingsStore } from './settings';
 
 export async function initialise(plugin: KindlePlugin): Promise<void> {

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -1,8 +1,8 @@
 import { writable } from 'svelte/store';
 
-import type KindlePlugin from '../index';
-import defaultTemplate from '../assets/defaultTemplate.njk';
-import type { SyncMode } from '../models';
+import defaultTemplate from '~/assets/defaultTemplate.njk';
+import type KindlePlugin from '~/.';
+import type { SyncMode } from '~/models';
 
 type SyncHistory = {
   totalBooks: number;

--- a/src/store/statusBar.ts
+++ b/src/store/statusBar.ts
@@ -1,8 +1,8 @@
 import { writable, derived } from 'svelte/store';
 
-import type { Book } from '../models';
-import { santizeTitle } from '../utils';
-import { settingsStore, syncSessionStore } from './index';
+import type { Book } from '~/models';
+import { santizeTitle } from '~/utils';
+import { settingsStore, syncSessionStore } from './';
 
 const { moment } = window;
 

--- a/src/store/syncSession.ts
+++ b/src/store/syncSession.ts
@@ -1,7 +1,7 @@
 import { writable } from 'svelte/store';
 
-import type { Book, SyncMode } from '../models';
-import { statusBarStore, settingsStore } from '../store';
+import type { Book, SyncMode } from '~/models';
+import { statusBarStore, settingsStore } from '~/store';
 
 type SyncJob = {
   status: 'idle' | 'in-progress' | 'done' | 'error';

--- a/src/sync/syncAmazon.ts
+++ b/src/sync/syncAmazon.ts
@@ -1,16 +1,16 @@
 import { filterAsync } from 'lodasync';
 import { get } from 'svelte/store';
 
-import AmazonLoginModal from '../components/amazonLoginModal';
-import type FileManager from '../fileManager';
-import { settingsStore, syncSessionStore } from '../store';
-import type { Book, BookMetadata } from '../models';
+import AmazonLoginModal from '~/components/amazonLoginModal';
+import type FileManager from '~/fileManager';
+import { settingsStore, syncSessionStore } from '~/store';
+import type { Book, BookMetadata } from '~/models';
 import {
   scrapeHighlightsForBook,
   scrapeBookMetadata,
   scrapeBooks,
-} from '../scraper';
-import { Renderer } from '../renderer';
+} from '~/scraper';
+import { Renderer } from '~/renderer';
 import type { SyncState } from './syncState';
 
 const initialState = { newBooksSynced: 0, newHighlightsSynced: 0 };

--- a/src/sync/syncClippings/index.ts
+++ b/src/sync/syncClippings/index.ts
@@ -1,10 +1,10 @@
-import type FileManager from '../../fileManager';
-import type { BookHighlight } from '../../models';
-import { Renderer } from '../../renderer';
+import type FileManager from '~/fileManager';
+import type { BookHighlight } from '~/models';
+import type { SyncState } from '~/sync/syncState';
+import { Renderer } from '~/renderer';
 import { openDialog } from './openDialog';
 import { parseBooks } from './parseBooks';
-import { syncSessionStore } from '../../store';
-import type { SyncState } from '../syncState';
+import { syncSessionStore } from '~/store';
 
 const initialState = { newBooksSynced: 0, newHighlightsSynced: 0 };
 

--- a/src/sync/syncClippings/parseBooks.ts
+++ b/src/sync/syncClippings/parseBooks.ts
@@ -1,7 +1,7 @@
 import * as kc from '@hadynz/kindle-clippings';
 import fs from 'fs';
 
-import type { BookHighlight } from '../../models';
+import type { BookHighlight } from '~/models';
 
 export const toBookHighlight = (book: kc.Book): BookHighlight => {
   return {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { santizeTitle } from '../src/utils';
+import { santizeTitle } from '~/utils';
 
 describe('Santize title for Obsidian environment', () => {
   it('strip book description in title after colon', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "types": ["node", "svelte", "jest"],
     "baseUrl": ".",
     "paths": {
-      "src": ["src/*", "tests/*"]
+      "src": ["src/*", "tests/*"],
+      "~/*": ["src/*"]
     }
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,6 +49,7 @@ module.exports = {
   resolve: {
     alias: {
       svelte: path.resolve('node_modules', 'svelte'),
+      '~': path.resolve(__dirname, 'src'),
     },
     extensions: ['.ts', '.tsx', '.js', '.svelte'],
     mainFields: ['svelte', 'browser', 'module', 'main'],


### PR DESCRIPTION
Configure tilde `~` as an alias for the `src` directory. This simplifies all import statements in the code. Makes refactoring and moving of files under different subdirectories much easier as references to other relative files will not need to change.