### PR TITLE
Book title short by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ your online Amazon account.
 
 | Tag | Description | Amazon sync | My Clippings sync |
 |-|-|-|-|
-| `{{title}}` | Book title | Always available | Always available |
+| `{{title}}` | Shortened book title | Always available | Always available |
+| `{{fullTitle}}` | Full book title | Always available | Always available |
 | `{{author}}` | Book author | Always available if book purchased from Amazon | Optional |
 | `{{asin}}` | Book ASIN | Always available if book purchased from Amazon | Not available |
 | `{{url}}` | Book URL on Amazon | Always available if book has an ASIN | Not available |

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-kindle-plugin",
   "name": "Kindle Highlights",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "minAppVersion": "0.10.2",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "author": "Hady Osman",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-kindle-plugin",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "main": "src/index.ts",
   "repository": {

--- a/src/models.ts
+++ b/src/models.ts
@@ -32,6 +32,7 @@ export type BookMetadata = {
 
 export type RenderTemplate = Book &
   BookMetadata & {
+    fullTitle: string;
     appLink?: string;
     highlights: {
       text: string;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,6 +1,7 @@
 import nunjucks from 'nunjucks';
 import { get } from 'svelte/store';
 
+import { santizeTitle } from '~/utils';
 import { settingsStore } from '~/store';
 import type { BookHighlight, RenderTemplate } from '~/models';
 
@@ -23,6 +24,8 @@ export class Renderer {
 
     const context: RenderTemplate = {
       ...book,
+      fullTitle: book.title,
+      title: santizeTitle(book.title),
       ...(book.asin
         ? { appLink: `kindle://book?action=open&asin=${book.asin}` }
         : {}),

--- a/src/settingsTab/templateInstructions.html
+++ b/src/settingsTab/templateInstructions.html
@@ -7,7 +7,8 @@ rendering every synced Kindle note highlights.
 
 Book
 <ul>
-  <li><span class="u-pop">{{title}}</span> - Title</li>
+  <li><span class="u-pop">{{title}}</span> - Title (shortened)</li>
+  <li><span class="u-pop">{{fullTitle}}</span> - Title (full)</li>
   <li><span class="u-pop">{{author}}</span> - Author</li>
   <li>
     <span class="u-pop">{{asin}}</span> - Amazon Standard Identification Number


### PR DESCRIPTION
As suggested [here][1] by [pgomez][2], this PR allows introduces a "short" and a "full" book title.

By default references to book title (i.e. `{{title}}`) will be of shortened format. `{{fullTitle}}` will be the complete long book title were applicable.

For example, the book "Atomic Habits: An Easy & Proven Way to Build Good Habits & Break Bad Ones":

- `title` — "Atomic Habits"
- `fullTitle` — "Atomic Habits: An Easy & Proven Way to Build Good Habits & Break Bad Ones"

[1]: https://github.com/hadynz/obsidian-kindle-plugin/discussions/42
[2]: https://github.com/pgomez