### PR TITLE
Add Japanese support for online Amazon sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Configure the settings of the plugin to specify the folder location for your syn
 - **Sync on startup [default: off]**: Enable to always automatically sync your latest highlights
   using your Amazon account
 - **Reset sync**: Wipe your sync history (number of books and highlights synced). Does **not**
-  delete any previously synced notes from your vault.
+  delete any previously synced notes from your vault
+- **Amazon region**: Select the Amazon account region which has your Kindle highlights data. 
+  Currently only global (.com) and Japan are supported
 - **Sign out**: Log out from your Amazon account (appears only if you have logged in)
 
 ## Usage

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-kindle-plugin",
   "name": "Kindle Highlights",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "minAppVersion": "0.10.2",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "author": "Hady Osman",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-kindle-plugin",
-  "version": "0.2.7",
+  "version": "0.2.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-kindle-plugin",
-      "version": "0.2.7",
+      "version": "0.2.11",
       "license": "MIT",
       "dependencies": {
         "@hadynz/kindle-clippings": "^1.0.8",
@@ -14,7 +14,6 @@
         "lodash.pickby": "^4.6.0",
         "lodasync": "^1.0.7",
         "nunjucks": "^3.2.3",
-        "query-string": "^7.0.0",
         "sanitize-filename": "^1.6.3",
         "svelte-loading-spinners": "^0.1.4"
       },
@@ -3110,6 +3109,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4363,14 +4363,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/find-cache-dir": {
@@ -8261,23 +8253,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/query-string": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.0.tgz",
-      "integrity": "sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -9545,14 +9520,6 @@
       "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
-    "node_modules/split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -9720,14 +9687,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/string_decoder": {
@@ -13862,7 +13821,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -14831,11 +14791,6 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
-    },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "find-cache-dir": {
       "version": "3.3.1",
@@ -17798,17 +17753,6 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "query-string": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.0.tgz",
-      "integrity": "sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -18814,11 +18758,6 @@
       "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -18951,11 +18890,6 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string_decoder": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-kindle-plugin",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "main": "src/index.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "lodash.pickby": "^4.6.0",
     "lodasync": "^1.0.7",
     "nunjucks": "^3.2.3",
-    "query-string": "^7.0.0",
     "sanitize-filename": "^1.6.3",
     "svelte-loading-spinners": "^0.1.4"
   },

--- a/src/amazonRegion.ts
+++ b/src/amazonRegion.ts
@@ -1,0 +1,24 @@
+import { get } from 'svelte/store';
+
+import type { AmazonAccount, AmazonAccountRegion } from '~/models';
+import { settingsStore } from '~/store';
+
+export const AmazonRegions: Record<AmazonAccountRegion, AmazonAccount> = {
+  global: {
+    name: 'Global',
+    hostname: 'amazon.com',
+    kindleReaderUrl: 'https://read.amazon.com',
+    notebookUrl: 'https://read.amazon.com/notebook',
+  },
+  japan: {
+    name: 'Japan',
+    hostname: 'amazon.co.jp',
+    kindleReaderUrl: 'https://read.amazon.co.jp',
+    notebookUrl: 'https://read.amazon.co.jp/notebook',
+  },
+};
+
+export const currentAmazonRegion = (): AmazonAccount => {
+  const selectedRegion = get(settingsStore).amazonRegion;
+  return AmazonRegions[selectedRegion];
+};

--- a/src/components/syncModal/views/SyncingView.svelte
+++ b/src/components/syncModal/views/SyncingView.svelte
@@ -3,11 +3,13 @@
 
   import { santizeTitleExcess } from '~/utils';
   import { syncSessionStore } from '~/store';
+  import { currentAmazonRegion } from '~/amazonRegion';
 
   let progressMessage: string;
 
   $: if ($syncSessionStore.status === 'login') {
-    progressMessage = 'Logging into Amazon.com';
+    const region = currentAmazonRegion();
+    progressMessage = `Logging into ${region.hostname}`;
   } else if ($syncSessionStore?.method === 'amazon') {
     progressMessage = 'Looking for new Kindle highlights to sync...';
   } else {

--- a/src/models.ts
+++ b/src/models.ts
@@ -45,3 +45,12 @@ export type RenderTemplate = Book &
   };
 
 export type SyncMode = 'amazon' | 'my-clippings';
+
+export type AmazonAccountRegion = 'global' | 'japan';
+
+export type AmazonAccount = {
+  name: string;
+  hostname: string;
+  kindleReaderUrl: string;
+  notebookUrl: string;
+};

--- a/src/scraper/scrapeBookHighlights.ts
+++ b/src/scraper/scrapeBookHighlights.ts
@@ -2,6 +2,7 @@ import type { Root } from 'cheerio';
 
 import type { Book, Highlight } from '~/models';
 import { loadRemoteDom } from './loadRemoteDom';
+import { currentAmazonRegion } from '~/amazonRegion';
 
 const mapTextToColor = (colorText: string): Highlight['color'] => {
   switch (colorText?.toLowerCase()) {
@@ -44,8 +45,9 @@ export const parseHighlights = ($: Root): Highlight[] => {
 };
 
 const scrapeBookHighlights = async (book: Book): Promise<Highlight[]> => {
+  const region = currentAmazonRegion();
   const dom = await loadRemoteDom(
-    `https://read.amazon.com/notebook?asin=${book.asin}&contentLimitState=&`
+    `${region.notebookUrl}?asin=${book.asin}&contentLimitState=&`
   );
 
   return parseHighlights(dom);

--- a/src/scraper/scrapeBooks.ts
+++ b/src/scraper/scrapeBooks.ts
@@ -2,6 +2,7 @@ import type { Root } from 'cheerio';
 
 import type { Book } from '~/models';
 import { loadRemoteDom } from './loadRemoteDom';
+import { currentAmazonRegion } from '~/amazonRegion';
 
 export const parseBooks = ($: Root): Book[] => {
   const booksEl = $('.kp-notebook-library-each-book').toArray();
@@ -23,7 +24,8 @@ export const parseBooks = ($: Root): Book[] => {
 };
 
 const scrapeBooks = async (): Promise<Book[]> => {
-  const dom = await loadRemoteDom('https://read.amazon.com/notebook', 1000);
+  const region = currentAmazonRegion();
+  const dom = await loadRemoteDom(region.notebookUrl, 1000);
   return parseBooks(dom);
 };
 

--- a/src/scraper/scrapeLogoutUrl.ts
+++ b/src/scraper/scrapeLogoutUrl.ts
@@ -1,6 +1,7 @@
 import type { Root } from 'cheerio';
 
 import { loadRemoteDom } from './loadRemoteDom';
+import { currentAmazonRegion } from '~/amazonRegion';
 
 export const parseSignoutLink = ($: Root): string => {
   const signoutLinkEl = $('#kp-notebook-head tr:last-child a').attr('href');
@@ -13,7 +14,8 @@ export const parseSignoutLink = ($: Root): string => {
 };
 
 const scrapeLogoutUrl = async (): Promise<string> => {
-  const dom = await loadRemoteDom('https://read.amazon.com/notebook');
+  const region = currentAmazonRegion();
+  const dom = await loadRemoteDom(region.notebookUrl);
   return parseSignoutLink(dom);
 };
 

--- a/src/settingsTab/index.ts
+++ b/src/settingsTab/index.ts
@@ -5,9 +5,11 @@ import { get } from 'svelte/store';
 import AmazonLogoutModal from '~/components/amazonLogoutModal';
 import templateInstructions from './templateInstructions.html';
 import type KindlePlugin from '~/.';
+import type { AmazonAccountRegion } from '~/models';
 import { Renderer } from '~/renderer';
 import { settingsStore } from '~/store';
 import { scrapeLogoutUrl } from '~/scraper';
+import { AmazonRegions } from '~/amazonRegion';
 
 const { moment } = window;
 
@@ -34,6 +36,7 @@ export class SettingsTab extends PluginSettingTab {
     this.downloadBookMetadata();
     this.syncOnBoot();
     this.noteTemplate();
+    this.amazonRegion();
     this.resetSyncHistory();
   }
 
@@ -66,6 +69,26 @@ export class SettingsTab extends PluginSettingTab {
             await modal.doLogout();
 
             this.display(); // rerender
+          });
+      });
+  }
+
+  private amazonRegion(): void {
+    new Setting(this.containerEl)
+      .setName('Amazon region')
+      .setDesc(
+        "Amazon's kindle reader is region specific. Choose your preferred country/region which has your highlights"
+      )
+      .addDropdown((dropdown) => {
+        Object.keys(AmazonRegions).forEach((region: AmazonAccountRegion) => {
+          const account = AmazonRegions[region];
+          dropdown.addOption(region, `${account.name} (${account.hostname})`);
+        });
+
+        return dropdown
+          .setValue(get(settingsStore).amazonRegion)
+          .onChange(async (value: AmazonAccountRegion) => {
+            await settingsStore.actions.setAmazonRegion(value);
           });
       });
   }

--- a/src/settingsTab/index.ts
+++ b/src/settingsTab/index.ts
@@ -48,7 +48,7 @@ export class SettingsTab extends PluginSettingTab {
     `);
 
     new Setting(this.containerEl)
-      .setName(`Logged in as ${get(settingsStore).loggedInEmail}`)
+      .setName('Logged in to Amazon Kindle Reader')
       .setDesc(descFragment)
       .addButton((button) => {
         return button

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -2,7 +2,7 @@ import { writable } from 'svelte/store';
 
 import defaultTemplate from '~/assets/defaultTemplate.njk';
 import type KindlePlugin from '~/.';
-import type { SyncMode } from '~/models';
+import type { SyncMode, AmazonAccountRegion } from '~/models';
 
 type SyncHistory = {
   totalBooks: number;
@@ -10,6 +10,7 @@ type SyncHistory = {
 };
 
 type Settings = {
+  amazonRegion: AmazonAccountRegion;
   highlightsFolder: string;
   lastSyncDate?: Date;
   lastSyncMode: SyncMode;
@@ -21,6 +22,7 @@ type Settings = {
 };
 
 const DEFAULT_SETTINGS: Settings = {
+  amazonRegion: 'global',
   highlightsFolder: '/',
   lastSyncMode: 'amazon',
   isLoggedIn: false,
@@ -139,6 +141,13 @@ const createSettingsStore = () => {
     });
   };
 
+  const setAmazonRegion = (value: AmazonAccountRegion) => {
+    store.update((state) => {
+      state.amazonRegion = value;
+      return state;
+    });
+  };
+
   return {
     subscribe: store.subscribe,
     initialise,
@@ -153,6 +162,7 @@ const createSettingsStore = () => {
       setLastSyncMode,
       setDownloadBookMetadata,
       incrementHistory,
+      setAmazonRegion,
     },
   };
 };

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -13,7 +13,6 @@ type Settings = {
   highlightsFolder: string;
   lastSyncDate?: Date;
   lastSyncMode: SyncMode;
-  loggedInEmail?: string;
   isLoggedIn: boolean;
   noteTemplate: string;
   syncOnBoot: boolean;
@@ -90,10 +89,9 @@ const createSettingsStore = () => {
     });
   };
 
-  const login = (value: string) => {
+  const login = () => {
     store.update((state) => {
       state.isLoggedIn = true;
-      state.loggedInEmail = value;
       return state;
     });
   };
@@ -101,7 +99,6 @@ const createSettingsStore = () => {
   const logout = () => {
     store.update((state) => {
       state.isLoggedIn = false;
-      state.loggedInEmail = undefined;
       return state;
     });
   };

--- a/src/sync/syncAmazon/index.ts
+++ b/src/sync/syncAmazon/index.ts
@@ -11,7 +11,7 @@ import {
   scrapeBooks,
 } from '~/scraper';
 import { Renderer } from '~/renderer';
-import type { SyncState } from './syncState';
+import type { SyncState } from '~/sync/syncState';
 
 const initialState = { newBooksSynced: 0, newHighlightsSynced: 0 };
 


### PR DESCRIPTION
Kindle users in Japan cannot access their highlights from `https://read.amazon.com`. They must use `https://read.amazon.co.jp`.

This PR introduces the ability for the plugin to support multiple regions. Japan is the first non-global region to be added as it is the only known use case so far.