### PR TITLE
Paginate over highlights

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-kindle-plugin",
   "name": "Kindle Highlights",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "minAppVersion": "0.10.2",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "author": "Hady Osman",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-kindle-plugin",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "main": "src/index.ts",
   "repository": {

--- a/src/scraper/scrapeBookHighlights.ts
+++ b/src/scraper/scrapeBookHighlights.ts
@@ -79,7 +79,6 @@ const scrapeBookHighlights = async (book: Book): Promise<Highlight[]> => {
 
   while (hasNextPage) {
     const data = await loadAndScrapeHighlights(book, url);
-    console.log('loop', data);
 
     results = [...results, ...data.highlights];
 


### PR DESCRIPTION
When syncing via Amazon online, a book with a large number of highlights (usually more than 50) requires the plugin to paginate to get the next set of 50.

This PR adds functionality to the plugin to determine if there are more highlights to be expected, and to keep paginating until running out of any more pages.