### PR TITLE
Support Spain region

### DIFF
--- a/src/amazonRegion.ts
+++ b/src/amazonRegion.ts
@@ -16,6 +16,12 @@ export const AmazonRegions: Record<AmazonAccountRegion, AmazonAccount> = {
     kindleReaderUrl: 'https://read.amazon.co.jp',
     notebookUrl: 'https://read.amazon.co.jp/notebook',
   },
+  spain: {
+    name: 'Spain',
+    hostname: 'amazon.es',
+    kindleReaderUrl: 'https://leer.amazon.es',
+    notebookUrl: 'https://leer.amazon.es/notebook',
+  }
 };
 
 export const currentAmazonRegion = (): AmazonAccount => {


### PR DESCRIPTION
For some reason, I can't load my highlights on `https://read.amazon.com/notebook` (.com), but it's working in the spanish one. So adding the support here will enable those cases.