### PR TITLE
Let's try this again! Fixes status bar timer stat

### DIFF
--- a/src/components/statusBar/StatusBar.svelte
+++ b/src/components/statusBar/StatusBar.svelte
@@ -4,6 +4,10 @@
   import CircleTick from '~/assets/circleTick.svg';
   import CircleExclamation from '~/assets/circleExclamation.svg';
   import { statusBarStore, settingsStore } from '~/store';
+  import moment from 'moment';
+
+  let lastSyncText = '';
+  setInterval(() => lastSyncText = `Last sync ${moment($statusBarStore.lastSyncDate).fromNow()}.`, 3000);
 </script>
 
 <div class="kp-statusbar--wrapper">
@@ -21,7 +25,7 @@
     </div>
   {/if}
   <div class="kp-statusbar--status">
-    {$statusBarStore.text}
+    {lastSyncText}
   </div>
 </div>
 

--- a/src/components/syncModal/views/SyncStats.svelte
+++ b/src/components/syncModal/views/SyncStats.svelte
@@ -22,7 +22,7 @@
     </div>
   </div>
   <div class="kp-stats--sync-date">
-    Last sync {moment(lastSyncDate).fromNow()}
+    Last sync { setInterval(function(){ moment(lastSyncDate).fromNow(); }, 3000);}
   </div>
 </div>
 

--- a/src/components/syncModal/views/SyncStats.svelte
+++ b/src/components/syncModal/views/SyncStats.svelte
@@ -22,7 +22,7 @@
     </div>
   </div>
   <div class="kp-stats--sync-date">
-    Last sync { setInterval(function(){ moment(lastSyncDate).fromNow(); }, 3000);}
+    Last sync {moment(lastSyncDate).fromNow()}
   </div>
 </div>
 

--- a/src/store/statusBar.ts
+++ b/src/store/statusBar.ts
@@ -17,7 +17,9 @@ const createStatusBarStore = () => {
 
       if (!isSyncing && $settings.lastSyncDate) {
         const booksCount = $settings.history.totalBooks;
-        const lastSyncText = `Last sync ${moment($settings.lastSyncDate).fromNow()}`;
+        const lastSyncText = `Last sync ${moment(
+          $settings.lastSyncDate
+        ).fromNow()}`;
 
         if (booksCount === 0) {
           text = `No books found to sync. ${lastSyncText}`;

--- a/src/store/statusBar.ts
+++ b/src/store/statusBar.ts
@@ -17,9 +17,7 @@ const createStatusBarStore = () => {
 
       if (!isSyncing && $settings.lastSyncDate) {
         const booksCount = $settings.history.totalBooks;
-        const lastSyncText = `Last sync ${moment(
-          $settings.lastSyncDate
-        ).fromNow()}`;
+        const lastSyncText = `Last sync ${moment($settings.lastSyncDate).fromNow()}`;
 
         if (booksCount === 0) {
           text = `No books found to sync. ${lastSyncText}`;
@@ -30,7 +28,8 @@ const createStatusBarStore = () => {
         }
       }
 
-      return { text, isSyncing };
+      const lastSyncDate = $settings.lastSyncDate;
+      return { text, isSyncing, lastSyncDate };
     }
   );
 


### PR DESCRIPTION
I love this plugin. One tiny thing that bothers me is the timer on the status bar never updates the last-synced time; the current status bar always reads "Last sync a few seconds ago."

This is a small change that will mean the status bar will look something like this after a while: 

![image](https://user-images.githubusercontent.com/9327688/122972836-6d023f00-d345-11eb-8ad1-d3c102b86b91.png)

Please let me know if this type of change is unwelcome or if you'd like to see any modifications!
