### PR TITLE
Sync without an h

### DIFF
--- a/src/components/syncModal/views/SyncingView.svelte
+++ b/src/components/syncModal/views/SyncingView.svelte
@@ -45,7 +45,7 @@
         <span class="kp-syncmodal--progress-current">{doneTotal}</span>
         <span class="kp-syncmodal--progress-total">/ {total}</span>
         <div class="kp-syncmodal--download">
-          Synching
+          Syncing
           <span class="kp-syncmodal--book-name">
             {santizeTitleExcess(currentJob.book.title)}
           </span>


### PR DESCRIPTION
This is the tiniest of tiny changes to drop the `h` on the syncing modal. I will not be offended if you close this without merging and/or comment, but I think it's worth proposing the change!