### PR TITLE
Fix nunjucks filters

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-kindle-plugin",
   "name": "Kindle Highlights",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "minAppVersion": "0.10.2",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "author": "Hady Osman",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-kindle-plugin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "main": "src/index.ts",
   "repository": {

--- a/src/eventEmitter.ts
+++ b/src/eventEmitter.ts
@@ -24,7 +24,3 @@ interface MessageEvents {
 }
 
 export const ee = new EventEmitter() as TypedEmitter<MessageEvents>;
-
-ee.on('syncSessionFailure', console.error);
-ee.on('syncBookFailure', console.error);
-ee.on('resyncFailure', console.error);

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -65,7 +65,7 @@ export class Renderer {
     const userTemplate =
       get(settingsStore).highlightTemplate || this.defaultHighlightTemplate();
 
-    const highlightTemplate = highlightTemplateWrapper.replace('{{content}}', userTemplate);
+    const highlightTemplate = highlightTemplateWrapper.replace('{{ content }}', userTemplate);
 
     const renderedHighlight = this.nunjucks.renderString(highlightTemplate, highlightParams);
 

--- a/src/renderer/templates/defaultHighlightTemplate.njk
+++ b/src/renderer/templates/defaultHighlightTemplate.njk
@@ -1,4 +1,4 @@
-{{ text | capitalize}} — location: [{{ location }}]({{ appLink }})
+{{ text }} — location: [{{ location }}]({{ appLink }})
 
 {% if note %}{{note}}{% endif %}
 

--- a/src/renderer/templates/defaultHighlightTemplate.njk
+++ b/src/renderer/templates/defaultHighlightTemplate.njk
@@ -1,4 +1,4 @@
-{{text}} — location: [{{location}}]({{appLink}})
+{{ text | capitalize}} — location: [{{ location }}]({{ appLink }})
 
 {% if note %}{{note}}{% endif %}
 

--- a/src/renderer/templates/highlightTemplateWrapper.njk
+++ b/src/renderer/templates/highlightTemplateWrapper.njk
@@ -1,3 +1,3 @@
 {% blockref "text", "id" %}
-{{content}}
+{{ content }}
 {% endblockref %}

--- a/src/settingsTab/index.ts
+++ b/src/settingsTab/index.ts
@@ -75,6 +75,7 @@ export class SettingsTab extends PluginSettingTab {
 
               await settingsStore.actions.logout();
             } catch (error) {
+              console.error('Error when trying to logout', error);
               ee.emit('logoutFailure');
             }
 

--- a/src/sync/syncAmazon/index.ts
+++ b/src/sync/syncAmazon/index.ts
@@ -30,6 +30,7 @@ export default class SyncAmazon {
 
       ee.emit('syncSessionSuccess');
     } catch (error) {
+      console.error('Error while trying fetch books and to sync', error);
       ee.emit('syncSessionFailure', String(error));
     }
   }
@@ -53,6 +54,7 @@ export default class SyncAmazon {
 
       ee.emit('resyncComplete', file, diffs.length);
     } catch (error) {
+      console.error('Error resyncing higlights for file', file, error);
       ee.emit('resyncFailure', file, String(error));
     }
   }
@@ -78,6 +80,7 @@ export default class SyncAmazon {
 
         ee.emit('syncBookSuccess', book, highlights);
       } catch (error) {
+        console.error('Error syncing book', book, error);
         ee.emit('syncBookFailure', book, String(error));
       }
     }

--- a/src/sync/syncClippings/index.ts
+++ b/src/sync/syncClippings/index.ts
@@ -26,6 +26,7 @@ export default class SyncKindleClippings {
     } catch (error) {
       const message = `Error parsing ${clippingsFile}.\n\n${error}`;
       ee.emit('syncSessionFailure', message);
+      console.error(message);
     }
   }
 }


### PR DESCRIPTION
Users should be able to utilise nunjucks filters.

To support the dynamic insertion of block references at the end of line that contains annotation text, the plugin was looking for the nunjucks annotation text reference to find the line number. It didn't factor that users could be using filters.