### PR TITLE
Fix regex not working in highlight template

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-kindle-plugin",
   "name": "Kindle Highlights",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "minAppVersion": "0.10.2",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "author": "Hady Osman",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-kindle-plugin",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "main": "src/index.ts",
   "repository": {

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -33,7 +33,7 @@ export class Renderer {
 
   public validate(template: string): boolean {
     try {
-      this.nunjucks.renderString(template, {});
+      this.nunjucks.renderString(template, { text: '' });
       return true;
     } catch (error) {
       return false;


### PR DESCRIPTION
Template validation was passing in an empty highlights object. This didn't play well when a template was using a regex replace as it expected an initialised `{{text}}` value to be provided.