### PR TITLE
Bring back manifest file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "obsidian-kindle-plugin",
+  "name": "Kindle Highlights",
+  "version": "1.5.1",
+  "minAppVersion": "0.10.2",
+  "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
+  "author": "Hady Osman",
+  "authorUrl": "https://hady.geek.nz",
+  "isDesktopOnly": true
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-kindle-plugin",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "main": "src/index.ts",
   "repository": {
@@ -16,12 +16,12 @@
   "license": "MIT",
   "scripts": {
     "prettier": "prettier --write '**/*.{ts,js,css,html}'",
+    "lint": "tsc --noemit && svelte-check && eslint . --ext .ts",
     "clean": "rimraf dist main.js*",
     "test": "jest",
     "test-watch": "jest --watch",
-    "build": "NODE_ENV=production webpack",
-    "lint": "tsc --noemit && svelte-check && eslint . --ext .ts",
     "dev": "NODE_ENV=development webpack && cp ./dist/main.js* .",
+    "build": "NODE_ENV=production webpack",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -48,8 +48,8 @@
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "babel-loader": "^8.2.2",
+    "copy-webpack-plugin": "^10.0.0",
     "electron": "^12.0.4",
-    "emit-file-webpack-plugin": "^2.0.1",
     "eslint": "^7.24.0",
     "faker": "^5.5.3",
     "husky": "^7.0.4",

--- a/packages/kindle-plugin/package-lock.json
+++ b/packages/kindle-plugin/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,26 +1,12 @@
 import path from 'path';
 import pack from './package.json';
 import sveltePreprocess from 'svelte-preprocess';
+import CopyPlugin from 'copy-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
-import EmitFilePlugin from 'emit-file-webpack-plugin';
 import SentryWebpackPlugin from '@sentry/webpack-plugin';
-import { Configuration, DefinePlugin, WebpackPluginInstance } from 'webpack';
+import { Configuration, DefinePlugin } from 'webpack';
 
 const isProduction = process.env.NODE_ENV === 'production';
-
-const obsidianManifestPlugin = new EmitFilePlugin({
-  filename: 'manifest.json',
-  content: () => ({
-    name: 'Kindle Highlights',
-    minAppVersion: '0.10.2',
-    isDesktopOnly: true,
-    id: pack.name,
-    version: pack.version,
-    description: pack.description,
-    author: pack.author.name,
-    authorUrl: pack.author.url,
-  }),
-});
 
 const sentryPlugin = new SentryWebpackPlugin({
   authToken: process.env.SENTRY_AUTH_TOKEN,
@@ -79,13 +65,15 @@ const config: Configuration = {
     ],
   },
   plugins: [
+    new CopyPlugin({
+      patterns: [{ from: './manifest.json', to: '.' }],
+    }),
     new DefinePlugin({
       PACKAGE_NAME: JSON.stringify(pack.name),
       VERSION: JSON.stringify(pack.version),
       PRODUCTION: JSON.stringify(isProduction),
     }),
     ...(isProduction ? [sentryPlugin] : []),
-    ...(isProduction ? [obsidianManifestPlugin as WebpackPluginInstance] : []),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
Mainfest.json is required by Obsidian to exist in repository for updates to be discovered on the fly