### PR TITLE
Added "My Clippings Path" preference to avoid having to find it manually each time

### DIFF
--- a/src/settingsTab/index.ts
+++ b/src/settingsTab/index.ts
@@ -34,12 +34,31 @@ export class SettingsTab extends PluginSettingTab {
     }
 
     this.highlightsFolder();
+    this.myClippingsFileLocation();
     this.amazonRegion();
     this.downloadBookMetadata();
     this.syncOnBoot();
     this.fileNameTemplate();
     this.highlightTemplate();
     this.sponsorMe();
+  }
+
+
+  private async myClippingsFileLocation(): void {
+    new Setting(this.containerEl)
+      .setName('My Clippings file location')
+      .setDesc(
+        "Set a path for the plugin to check for your \"My Clippings\" file, instead of asking to find it each time."
+      )
+      .addText(text => {
+        return text
+          .setPlaceholder('')
+          .setValue(get(settingsStore).myClippingsFileLocation)
+          .onChange((async (value: string) => {
+            await settingsStore.actions.setMyClippingsFileLocation(value);
+          }))
+
+      })
   }
 
   private async logout(): Promise<void> {

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -14,6 +14,7 @@ type Settings = {
   fileNameTemplate?: string;
   syncOnBoot: boolean;
   downloadBookMetadata: boolean;
+  myClippingsFileLocation: string;
 };
 
 const DEFAULT_SETTINGS: Settings = {
@@ -23,6 +24,7 @@ const DEFAULT_SETTINGS: Settings = {
   isLoggedIn: false,
   syncOnBoot: false,
   downloadBookMetadata: true,
+  myClippingsFileLocation: '',
 };
 
 const createSettingsStore = () => {
@@ -121,6 +123,13 @@ const createSettingsStore = () => {
     });
   };
 
+  const setMyClippingsFileLocation = (value: string) => {
+    store.update((state => {
+      state.myClippingsFileLocation = value;
+      return state;
+    }));
+  }
+
   const setFileNameTemplate = (value: string) => {
     store.update((state) => ({ ...state, fileNameTemplate: value }));
   };
@@ -159,6 +168,7 @@ const createSettingsStore = () => {
       setSyncOnBoot,
       setDownloadBookMetadata,
       setAmazonRegion,
+      setMyClippingsFileLocation,
       upgradeStoreState,
     },
   };

--- a/src/sync/syncClippings/index.ts
+++ b/src/sync/syncClippings/index.ts
@@ -3,12 +3,18 @@ import { openDialog } from './openDialog';
 import { parseBooks } from './parseBooks';
 import type { SyncManager } from '~/sync';
 
+import { get } from 'svelte/store';
+import { settingsStore } from '~/store';
+import { existsSync } from 'fs';
+
+
+type FindMyClippingsFileResponse = [ file: string, canceled: boolean ];
+
 export default class SyncKindleClippings {
   constructor(private syncManager: SyncManager) {}
 
   public async startSync(): Promise<void> {
-    const [clippingsFile, canceled] = await openDialog();
-
+    const [clippingsFile, canceled] = await this.findMyClippingsFile();
     if (canceled) {
       return; // Do nothing...
     }
@@ -27,6 +33,22 @@ export default class SyncKindleClippings {
       const message = `Error parsing ${clippingsFile}.\n\n${error}`;
       ee.emit('syncSessionFailure', message);
       console.error(message);
+    }
+  }
+
+  public async findMyClippingsFile(): Promise<FindMyClippingsFileResponse> {
+    /* First, check if setting for My Clippings path is specified */
+    const myClippingsPath = await get(settingsStore).myClippingsFileLocation;
+    
+    /* Check if this path actually exists */
+    const exists = myClippingsPath ? existsSync(myClippingsPath) : false;
+    
+    if(exists){
+      /* We found it! */
+      return [ myClippingsPath, false ];
+    } else {
+      /* We didn't... summon the file picker */
+      return await openDialog();
     }
   }
 }


### PR DESCRIPTION
Simple patch for #150

This patch adds a new preference to the plugin allowing the user to enter the path to their Kindle's My Clippings.txt file:

<img width="1086" alt="Screen Shot 2022-05-20 at 6 03 32 pm" src="https://user-images.githubusercontent.com/16063438/169577738-9e6d22e8-acba-4930-92b4-5305c177d6cf.png">

The user initiates a sync like usual and chooses the "Upload My Clippings File" option. The plugin checks to see if the "My Clippings.txt" path is set in its settings and — if it is, the plugin continues using this file. If it isn't, or the plugin is unable to find a file at the specified path, a file open dialog is displayed as usual.