### PR TITLE
Bump plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-kindle-plugin",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "main": "src/index.ts",
   "repository": {


### PR DESCRIPTION
Simple bump of version to create a release that brings in changes made in https://github.com/hadynz/kindle-clippings/releases/tag/2.0.8