### PR TITLE
Bump plugin version in both manifest+package.json files

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-kindle-plugin",
   "name": "Kindle Highlights",
-  "version": "1.8.1",
+  "version": "1.9.2",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "minAppVersion": "0.10.2",
   "author": "Hady Osman",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-kindle-plugin",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
   "main": "src/index.ts",
   "repository": {


### PR DESCRIPTION
Plugin version in `manifest.json` has fallen behind. This means that users do not get prompted inside Obsidian that there are plugin updates available.

This PR bumps the plugin version and updates `manifest.json`