### PR TITLE
Increase image cover size in URL to 1024px

### DIFF
--- a/src/scraper/scrapeBooks.ts
+++ b/src/scraper/scrapeBooks.ts
@@ -33,6 +33,11 @@ export const parseAuthor = (scrapedAuthor: string): string => {
   return scrapedAuthor.replace(/.*: /, '')?.trim();
 };
 
+export const parseImageUrl = (scrapedImageUrl: string): string => {
+  return scrapedImageUrl.replace(/\._SY\d+\./, '._SX1024.')?.trim();
+};
+
+
 export const parseBooks = ($: Root): Book[] => {
   const booksEl = $('.kp-notebook-library-each-book').toArray();
 
@@ -41,6 +46,7 @@ export const parseBooks = ($: Root): Book[] => {
 
     const scrapedLastAnnotatedDate = $('[id^="kp-notebook-annotated-date"]', bookEl).val();
     const scrapedAuthor = $('p.kp-notebook-searchable', bookEl).text();
+    const scrapedImageUrl = $('.kp-notebook-cover-image', bookEl).attr('src');
 
     return {
       id: hash(title),
@@ -48,7 +54,7 @@ export const parseBooks = ($: Root): Book[] => {
       title,
       author: parseAuthor(scrapedAuthor),
       url: `https://www.amazon.com/dp/${$(bookEl).attr('id')}`,
-      imageUrl: $('.kp-notebook-cover-image', bookEl).attr('src'),
+      imageUrl: parseImageUrl(scrapedImageUrl),
       lastAnnotatedDate: parseToDateString(
         scrapedLastAnnotatedDate,
         get(settingsStore).amazonRegion


### PR DESCRIPTION
I wanted to add covers to my book summaries but using `{{imageUrl}}` in the template resulted in tiny, barely legible, images.

The default URL pulled from Amazon are for images that are 160px in height.

Added a regex to change `imageUrl` to pull images that are 1024px in width.

If you want to render the image in the template, you can use the following markdown format (replace 320 with whatever width you want the image to render):

`{% if imageUrl %}![|320]({{imageUrl}}){% endif %}`

Considered adding this to the default template, but this seems to belong in a different PR.