### PR TITLE
Added a parameter on the startSync() function.

### DIFF
--- a/src/sync/syncClippings/index.ts
+++ b/src/sync/syncClippings/index.ts
@@ -7,8 +7,11 @@ import { parseBooks } from './parseBooks';
 export default class SyncKindleClippings {
   constructor(private syncManager: SyncManager) {}
 
-  public async startSync(): Promise<void> {
-    const [clippingsFile, canceled] = await openDialog();
+  public async startSync(clippingsFile? : string): Promise<void> {
+    let canceled = false;
+    if (typeof clippingsFile === 'undefined') {
+      [clippingsFile, canceled] = await openDialog();
+    }
 
     if (canceled) {
       return; // Do nothing...


### PR DESCRIPTION
Expose a parameter in order to use the function in another plugin. This is in order to make the API more accessible. 