### PR TITLE
Convert Book ID's to MD5 to reduce collisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "nunjucks-date-filter": "^0.1.1",
     "sanitize-filename": "^1.6.3",
     "svelte-loading-spinners": "^0.1.4",
+    "ts-md5": "^1.3.1",
     "typed-emitter": "^1.4.0"
   },
   "devDependencies": {

--- a/src/fileManager/mappers.ts
+++ b/src/fileManager/mappers.ts
@@ -5,6 +5,7 @@ import { get } from 'svelte/store';
 import type { Book, KindleFrontmatter } from '~/models';
 import { getRenderers } from '~/rendering';
 import { settingsStore } from '~/store';
+import { hash, hash_short } from "~/utils"
 
 /**
  * Returns a file path for a given book relative to the current Obsidian
@@ -31,8 +32,13 @@ export const bookToFrontMatter = (book: Book, highlightsCount: number): KindleFr
 
 export const frontMatterToBook = (frontmatter: KindleFrontmatter): Book => {
   const formats = ['MMM DD, YYYY', 'YYYY-MM-DD'];
+  let book_id: string = frontmatter.bookId
+  // If this note is still using a fletcher ID, convert it to MD5 for comparison
+  if (frontmatter.bookId == hash_short(frontmatter.title)) {
+    book_id = hash(frontmatter.title)
+  }
   return {
-    id: frontmatter.bookId,
+    id: book_id,
     title: frontmatter.title,
     author: frontmatter.author,
     asin: frontmatter.asin,

--- a/src/scraper/scrapeBookHighlights.ts
+++ b/src/scraper/scrapeBookHighlights.ts
@@ -2,7 +2,7 @@ import type { Root } from 'cheerio';
 
 import { currentAmazonRegion } from '~/amazonRegion';
 import type { Book, Highlight } from '~/models';
-import { br2ln, hash } from '~/utils';
+import { br2ln, hash_short } from '~/utils';
 
 import { loadRemoteDom } from './loadRemoteDom';
 
@@ -18,9 +18,8 @@ export const mapTextToColor = (highlightClasses: string): Highlight['color'] => 
 
 const highlightsUrl = (book: Book, state?: NextPageState): string => {
   const region = currentAmazonRegion();
-  return `${region.notebookUrl}?asin=${book.asin}&contentLimitState=${
-    state?.contentLimitState ?? ''
-  }&token=${state?.token ?? ''}`;
+  return `${region.notebookUrl}?asin=${book.asin}&contentLimitState=${state?.contentLimitState ?? ''
+    }&token=${state?.token ?? ''}`;
 };
 
 const parseNextPageState = ($: Root): NextPageState | null => {
@@ -40,7 +39,7 @@ const parseHighlights = ($: Root): Highlight[] => {
 
     const text = $('#highlight', highlightEl).text()?.trim();
     return {
-      id: hash(text),
+      id: hash_short(text),
       text,
       color,
       location: $('#kp-annotation-location', highlightEl).val(),

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,5 +1,10 @@
 import fletcher16 from 'fletcher';
+import { Md5 } from 'ts-md5';
 
 export const hash = (value: string): string => {
+  return Md5.hashStr(value.toLowerCase());
+};
+
+export const hash_short = (value: string): string => {
   return fletcher16(Buffer.from(value.toLowerCase())).toString();
 };


### PR DESCRIPTION
Keep fletcher hashes for the highlight refs.

Retains backwards compatibility with notes that store the old fletcher hashes, and will update them as new highlights are added

This is my attempt to fix this

## Why
I have two books that have their highlights merged to to being assigned the same bookID with the current hash used. I want to be able to have them seperate, but otherwise cause as little disruption as possible.

For interest, the two books are "The One Year Bible TLB" and "How to Develop Your Personal Mission Statement" 🤷 