### PR TITLE
Fixed problem with Author url always broken

### DIFF
--- a/src/scraper/scrapeBookMetadata.ts
+++ b/src/scraper/scrapeBookMetadata.ts
@@ -1,5 +1,6 @@
 import type { Root } from 'cheerio';
 
+import { currentAmazonRegion } from '~/amazonRegion';
 import type { Book, BookMetadata } from '~/models';
 
 import { loadRemoteDom } from './loadRemoteDom';
@@ -58,8 +59,10 @@ const parseIsbn = ($: Root): string | null => {
 };
 
 const parseAuthorUrl = ($: Root): string | null => {
-  const href = $('.contributorNameID').attr('href');
-  return `https://www.amazon.com${href}`;
+  const region = currentAmazonRegion();
+  const domainURL = `https://${region.hostname}`;
+  const href = $('a.a-size-base.a-link-normal.a-text-normal').attr('href');
+  return href ? `${domainURL}/${href}` : domainURL;
 };
 
 export const parseBookMetadata = ($: Root): BookMetadata => {
@@ -73,7 +76,9 @@ export const parseBookMetadata = ($: Root): BookMetadata => {
 };
 
 const scrapeBookMetadata = async (book: Book): Promise<BookMetadata> => {
-  const { dom } = await loadRemoteDom(`https://www.amazon.com/dp/${book.asin}`, 1000);
+  const region = currentAmazonRegion();
+  const domainURL = `https://${region.hostname}`;
+  const { dom } = await loadRemoteDom(`${domainURL}/dp/${book.asin}`, 1000);
 
   return parseBookMetadata(dom);
 };


### PR DESCRIPTION
- https://github.com/hadynz/obsidian-kindle-plugin/issues/248

The Amazon page structure appears to have changed.
The existing parser cannot retrieve the author URL.
And we also had to change the domain URL for each region.
I have fixed these issues.