### PR TITLE
Fix: Resolve incomplete many highlights sync by increasing timeout

### DIFF
--- a/src/scraper/scrapeBooks.ts
+++ b/src/scraper/scrapeBooks.ts
@@ -59,7 +59,7 @@ export const parseBooks = ($: Root): Book[] => {
 
 const scrapeBooks = async (): Promise<Book[]> => {
   const region = currentAmazonRegion();
-  const { dom } = await loadRemoteDom(region.notebookUrl, 1000);
+  const { dom } = await loadRemoteDom(region.notebookUrl, 30000);
   return parseBooks(dom);
 };
 


### PR DESCRIPTION
The Kindle notebook page uses infinite scrolling to load books. The previous 1-second timeout was insufficient to load all books for users with many highlights, resulting in an incomplete sync.

This change increases the scraping timeout from 1000ms to 30000ms, allowing more time for the page to load additional books before parsing.