### PR TITLE
Add Action Tags feature to render highlights as a markdown heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ You can extract your `My Clippings.txt` file by plugging it into your computer u
 
 - **Powerful, flexible templating with preview** — Customise your highlights and file names to your liking by configuring your own template using ([Nunjucks][2]) templating language with live preview
 
+- **Use "action tags" to render headings** — Make the highlighted text render as a markdown heading by adding a note to the highlight with the syntax `.h#` - with `#` being the heading level up to 6. This is similar to the functionality provided by [Readwise Action Tags](https://docs.readwise.io/reader/docs/faqs/action-tags).
+
 ## Mission statement
 
 Inspired by Obsidian's principle of "your data sitting in a local folder" and "never leaving

--- a/src/models.ts
+++ b/src/models.ts
@@ -18,6 +18,7 @@ export type Highlight = {
   note?: string;
   color?: 'pink' | 'blue' | 'yellow' | 'orange';
   createdDate?: Date;
+  isHeading?: boolean;
 };
 
 export type BookHighlight = {

--- a/src/rendering/nunjucks.extensions.ts
+++ b/src/rendering/nunjucks.extensions.ts
@@ -121,7 +121,9 @@ function BlockReferenceExtension(): void {
     const buffer = sb(renderedTemplate);
 
     const blockRef = `${HighlightIdBlockRefPrefix}${context.ctx[highlightId]}`;
-    const blockRefSuffixLine = `${buffer.getLine(this.lineNumber + 1)} ${blockRef}`;
+
+    // Add a new line before the ^ref if the highlight is a heading, otherwise it looks terrible
+    const blockRefSuffixLine = `${buffer.getLine(this.lineNumber + 1)}${context.ctx.isHeading ? "\n" : " "}${blockRef}`;
 
     buffer.replace({ line: this.lineNumber, content: blockRefSuffixLine });
     return new nunjucks.runtime.SafeString(buffer.toString());

--- a/src/rendering/renderer/highlightRenderer.spec.ts
+++ b/src/rendering/renderer/highlightRenderer.spec.ts
@@ -37,6 +37,7 @@ describe('HighlightRenderer', () => {
         page: '3',
         note: 'my smart note',
         color: 'pink',
+        isHeading: false
       };
 
       it.each([

--- a/src/rendering/renderer/templateVariables.ts
+++ b/src/rendering/renderer/templateVariables.ts
@@ -47,6 +47,7 @@ type HighlightTemplateVariables = CommonTemplateVariables & {
   color?: 'pink' | 'blue' | 'yellow' | 'orange';
   createdDate?: Date;
   appLink?: string;
+  isHeading?: boolean;
 };
 
 export const authorsTemplateVariables = (author: string): AuthorsTemplateVariables => {

--- a/src/rendering/templates/defaultHighlightTemplate.njk
+++ b/src/rendering/templates/defaultHighlightTemplate.njk
@@ -1,5 +1,6 @@
-{{ text }} — location: [{{ location }}]({{ appLink }})
-
-{% if note %}{{note}}{% endif %}
+{{ text }}
+{%- if not isHeading %} - location: [{{ location }}]({{ appLink }}){% endif %} 
+{% if isHeading %}location: [{{ location }}]({{ appLink }}){% endif %}
+{%if note %}{{note}}{% endif %}
 
 ---

--- a/src/scraper/scrapeBookHighlights.ts
+++ b/src/scraper/scrapeBookHighlights.ts
@@ -38,14 +38,55 @@ const parseHighlights = ($: Root): Highlight[] => {
     const highlightClasses = $('.kp-notebook-highlight', highlightEl).attr('class');
     const color = mapTextToColor(highlightClasses);
 
-    const text = $('#highlight', highlightEl).text()?.trim();
+    let text = $('#highlight', highlightEl).text()?.trim();
+    let note = br2ln($('#note', highlightEl).html());
+    let isHeading = false;
+    
+    if(note) {
+      // If the note is in the Action Tag heading syntax
+      // Render the highlighted 'text' as a heading
+      // Remove the note
+      switch (note.toLowerCase()) {
+        case ".h1":
+          text = `# ${text}`;
+          note = null;
+          isHeading = true;
+          break;
+        case ".h2":
+          text = `## ${text}`;
+          note = null;
+          isHeading = true;
+          break;
+        case ".h3":
+          text = `### ${text}`;
+          note = null;
+          isHeading = true;
+          break;
+        case ".h4":
+          text = `#### ${text}`;
+          note = null;
+          isHeading = true;
+          break;
+        case ".h5":
+          text = `##### ${text}`;
+          note = null;
+          break;
+        case ".h6":
+          text = `###### ${text}`;
+          note = null;
+          isHeading = true;
+          break;
+      }
+    }
+
     return {
       id: hash(text),
       text,
       color,
       location: $('#kp-annotation-location', highlightEl).val(),
       page: pageMatch ? pageMatch[0] : null,
-      note: br2ln($('#note', highlightEl).html()),
+      note,
+      isHeading,
     };
   });
 };

--- a/src/scraper/scrapeBookHighlights.ts
+++ b/src/scraper/scrapeBookHighlights.ts
@@ -2,7 +2,7 @@ import type { Root } from 'cheerio';
 
 import { currentAmazonRegion } from '~/amazonRegion';
 import type { Book, Highlight } from '~/models';
-import { br2ln, hash } from '~/utils';
+import { applyActionTags, br2ln, hash } from '~/utils';
 
 import { loadRemoteDom } from './loadRemoteDom';
 
@@ -38,56 +38,17 @@ const parseHighlights = ($: Root): Highlight[] => {
     const highlightClasses = $('.kp-notebook-highlight', highlightEl).attr('class');
     const color = mapTextToColor(highlightClasses);
 
-    let text = $('#highlight', highlightEl).text()?.trim();
-    let note = br2ln($('#note', highlightEl).html());
-    let isHeading = false;
-    
-    if(note) {
-      // If the note is in the Action Tag heading syntax
-      // Render the highlighted 'text' as a heading
-      // Remove the note
-      switch (note.toLowerCase()) {
-        case ".h1":
-          text = `# ${text}`;
-          note = null;
-          isHeading = true;
-          break;
-        case ".h2":
-          text = `## ${text}`;
-          note = null;
-          isHeading = true;
-          break;
-        case ".h3":
-          text = `### ${text}`;
-          note = null;
-          isHeading = true;
-          break;
-        case ".h4":
-          text = `#### ${text}`;
-          note = null;
-          isHeading = true;
-          break;
-        case ".h5":
-          text = `##### ${text}`;
-          note = null;
-          break;
-        case ".h6":
-          text = `###### ${text}`;
-          note = null;
-          isHeading = true;
-          break;
-      }
-    }
+    const text = $('#highlight', highlightEl).text()?.trim();
 
-    return {
+    return applyActionTags({
       id: hash(text),
       text,
       color,
       location: $('#kp-annotation-location', highlightEl).val(),
       page: pageMatch ? pageMatch[0] : null,
-      note,
-      isHeading,
-    };
+      note: br2ln($('#note', highlightEl).html()),
+      isHeading: false,
+    });
   });
 };
 

--- a/src/settings/templateEditorModal/components/TipsModal/Modal.svelte
+++ b/src/settings/templateEditorModal/components/TipsModal/Modal.svelte
@@ -108,6 +108,10 @@
           <td><Chip title={'appLink'} /></td>
           <td>Link to highlighted text in Kindle app</td>
         </tr>
+        <tr>
+          <td><Chip title={'isHeading'} /></td>
+          <td>True if the .h# action tag syntax was used to render the highlight text as a markdown heading</td>
+        </tr>
       </tbody>
     </table>
   {/if}

--- a/src/sync/diffManager/helpers.ts
+++ b/src/sync/diffManager/helpers.ts
@@ -43,12 +43,15 @@ export const diffLists = (
   remotes.forEach((r) => syncState.set(r.id, { highlight: r, exists: !diff.contains(r) }));
 
   return diff.map((remote): DiffResult => {
+    // Get the next full highlight that is already rendered (exists)
+    // Need this to see if it is renered as a heading or not as it affects the insert line
     const next = getNextNeighbour(syncState, remote.id);
     const nextRendered = renders.find((r) => r.highlightId === next?.id);
 
     return {
       remoteHighlight: remote,
-      nextRenderedHighlight: nextRendered,
+      nextHighlight: next,
+      nextRenderedHighlight: nextRendered
     };
   });
 };

--- a/src/sync/diffManager/index.ts
+++ b/src/sync/diffManager/index.ts
@@ -16,6 +16,7 @@ export type RenderedHighlight = {
 
 export type DiffResult = {
   remoteHighlight: Highlight;
+  nextHighlight: Highlight;
   nextRenderedHighlight?: RenderedHighlight;
 };
 
@@ -68,7 +69,9 @@ export class DiffManager {
     const insertList = diffs
       .filter((d) => d.nextRenderedHighlight)
       .map((d) => ({
-        line: d.nextRenderedHighlight?.line,
+        // If the user marked the highligh as a Heading the ^ref is on the following line
+        // So we have to subtract 1 from the ref line to find the place to insert new highlights
+        line: d.nextRenderedHighlight?.line - (d.nextHighlight.isHeading ? 1 : 0),
         content: highlightRenderer.render(d.remoteHighlight, this.kindleFile.book),
       }));
 

--- a/src/sync/syncClippings/parseBooks.ts
+++ b/src/sync/syncClippings/parseBooks.ts
@@ -2,7 +2,7 @@ import { Book, groupToBooks, readMyClippingsFile } from '@hadynz/kindle-clipping
 import fs from 'fs';
 
 import type { BookHighlight, Highlight } from '~/models';
-import { hash } from '~/utils';
+import { applyActionTags, hash } from '~/utils';
 
 const toBookHighlight = (book: Book): BookHighlight => {
   return {
@@ -13,16 +13,17 @@ const toBookHighlight = (book: Book): BookHighlight => {
     },
     highlights: book.annotations
       .filter((entry) => entry.type === 'HIGHLIGHT' || entry.type === 'UNKNOWN')
-      .map(
-        (entry): Highlight => ({
+      .map((entry): Highlight => {
+        return applyActionTags({
           id: hash(entry.content),
           text: entry.content,
           note: entry.note,
           location: entry.location?.display,
           page: entry.page?.display,
           createdDate: entry.createdDate,
-        })
-      ),
+          isHeading: false,
+        });
+      }),
   };
 };
 

--- a/src/utils/applyActionTags.ts
+++ b/src/utils/applyActionTags.ts
@@ -1,0 +1,42 @@
+import type { Highlight } from '~/models';
+
+export const applyActionTags = (highlight: Highlight): Highlight => {
+  if (highlight.note) {
+    switch (highlight.note) {
+      case '.h1':
+        highlight.text = `# ${highlight.text}`;
+        highlight.note = null;
+        highlight.isHeading = true;
+        break;
+      case '.h2':
+        highlight.text = `## ${highlight.text}`;
+        highlight.note = null;
+        highlight.isHeading = true;
+        break;
+      case '.h3':
+        highlight.text = `### ${highlight.text}`;
+        highlight.note = null;
+        highlight.isHeading = true;
+        break;
+      case '.h4':
+        highlight.text = `#### ${highlight.text}`;
+        highlight.note = null;
+        highlight.isHeading = true;
+        break;
+      case '.h5':
+        highlight.text = `##### ${highlight.text}`;
+        highlight.note = null;
+        highlight.isHeading = true;
+        break;
+      case '.h6':
+        highlight.text = `###### ${highlight.text}`;
+        highlight.note = null;
+        highlight.isHeading = true;
+        break;
+      default:
+        highlight.isHeading = false;
+    }
+  }
+
+  return highlight;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './br2ln';
 export * from './hash';
 export * from './stringBuffer';
 export * from './parseAuthor';
+export * from './applyActionTags';


### PR DESCRIPTION
Problem:
- The only feature Readwise has that that I need that this plugin doesn't have is rendering the highlighted text as a markdown heading.
- See the Readwise Action Tag feature here - https://docs.readwise.io/reader/docs/faqs/action-tags

This Pull Request:
- Renders highlights as markdown headings when you add a note with the same syntax as readwise (.h1 || .h2 || .h3 || .h4 || .h5 || .h6).
- Puts the ^ref-{{id}} under the heading if it's a heading being rendered (otherwise it looks weird).
- Accounts for the extra line above the ^ref-{{id}} when inserting new highlights above the already rendered ones.

Let me know what you think!