### PR TITLE
fix(305): Notes not displayed after sync

### DIFF
--- a/src/scraper/scrapeBookHighlights.ts
+++ b/src/scraper/scrapeBookHighlights.ts
@@ -76,7 +76,7 @@ const scrapeBookHighlights = async (book: Book): Promise<Highlight[]> => {
     hasNextPage = data.hasNextPage;
   }
 
-  return results.filter((h) => h.text);
+  return results.filter((h) => h.text || h.note);
 };
 
 export default scrapeBookHighlights;


### PR DESCRIPTION
All highlights (including notes) are retrieved from Amazon, but are filtered out prior to writing data to the users' vault. Note content is available inside the `note` property (only highlights have non-null `text` attributes).

This change ensures notes are not filtered out during syncs and subsequently displayed in users' vaults.