### PR TITLE
fix: Exception on Amazon logout

### DIFF
--- a/src/components/amazonLoginModal/index.ts
+++ b/src/components/amazonLoginModal/index.ts
@@ -23,6 +23,9 @@ export default class AmazonLoginModal {
       parent: remote.getCurrentWindow(),
       width: 450,
       height: 730,
+      webPreferences: {
+        partition: 'persist:kindle-highlights',
+      },
       show: false,
     });
 

--- a/src/components/amazonLogoutModal/index.ts
+++ b/src/components/amazonLogoutModal/index.ts
@@ -17,6 +17,9 @@ export default class AmazonLogoutModal {
       parent: remote.getCurrentWindow(),
       width: 450,
       height: 730,
+      webPreferences: {
+        partition: 'persist:kindle-highlights',
+      },
       show: false,
     });
 

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -2,5 +2,6 @@ import scrapeHighlightsForBook from './scrapeBookHighlights';
 import scrapeBookMetadata from './scrapeBookMetadata';
 import scrapeBooks from './scrapeBooks';
 import scrapeLogoutUrl from './scrapeLogoutUrl';
+import clearSessionData from './session';
 
-export { scrapeHighlightsForBook, scrapeBookMetadata, scrapeBooks, scrapeLogoutUrl };
+export { scrapeHighlightsForBook, scrapeBookMetadata, scrapeBooks, scrapeLogoutUrl, clearSessionData };

--- a/src/scraper/loadRemoteDom.ts
+++ b/src/scraper/loadRemoteDom.ts
@@ -16,6 +16,7 @@ export const loadRemoteDom = async (targetUrl: string, timeout = 0): Promise<Dom
     webPreferences: {
       webSecurity: false,
       nodeIntegration: false,
+      partition: 'persist:kindle-highlights',
     },
     show: false,
   });

--- a/src/scraper/session.ts
+++ b/src/scraper/session.ts
@@ -1,0 +1,25 @@
+import { BrowserWindow, remote } from 'electron';
+const { BrowserWindow: RemoteBrowserWindow } = remote;
+
+const clearSessionData = (): Promise<boolean> => {
+    const window: BrowserWindow = new RemoteBrowserWindow({
+        width: 1000,
+        height: 600,
+        webPreferences: {
+            webSecurity: false,
+            nodeIntegration: false,
+            partition: 'persist:kindle-highlights',
+        },
+        show: false,
+    });
+
+    return window.webContents.session.clearStorageData()
+        .then(() => {
+            return Promise.resolve(true);
+        }).catch(() => {
+            return Promise.resolve(false);
+        });
+}
+
+
+export default clearSessionData;

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -4,11 +4,10 @@ import { get } from 'svelte/store';
 
 import type KindlePlugin from '~/.';
 import { AmazonRegions, orderedAmazonRegions } from '~/amazonRegion';
-import AmazonLogoutModal from '~/components/amazonLogoutModal';
 import { ee } from '~/eventEmitter';
 import type FileManager from '~/fileManager';
 import type { AmazonAccountRegion } from '~/models';
-import { scrapeLogoutUrl } from '~/scraper';
+import { clearSessionData } from '~/scraper';
 import { settingsStore } from '~/store';
 
 import TemplateEditorModal from './templateEditorModal';
@@ -80,14 +79,7 @@ export class SettingsTab extends PluginSettingTab {
             ee.emit('startLogout');
 
             try {
-              const signout = await scrapeLogoutUrl();
-
-              // User is still logged in
-              if (signout.isStillLoggedIn) {
-                const modal = new AmazonLogoutModal(signout.url);
-                await modal.doLogout();
-              }
-
+              await clearSessionData();
               settingsStore.actions.logout();
             } catch (error) {
               console.error('Error when trying to logout', error);


### PR DESCRIPTION
This fix addresses https://github.com/hadynz/obsidian-kindle-plugin/issues/289

Cheerio is no longer able to scape the logout URL because the DOM changed this the last release of this plugin (the returned HTML is Javascript that references CoPilot, likely in an effort to stop crawlers).

This change stores session data in a [partition session](https://www.electronjs.org/docs/latest/api/session) that can be retrieved and deleted when the user logs out. This also means the logout modal is no longer displayed (so the sign-out process is one click).