### PR TITLE
fix(301): Sync on startup 'taking too long to load'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,10 +44,6 @@ export default class KindlePlugin extends Plugin {
 
     registerNotifications();
     this.registerEvents();
-
-    if (get(settingsStore).syncOnBoot) {
-      await this.startAmazonSync();
-    }
   }
 
   private registerEvents(): void {
@@ -70,7 +66,10 @@ export default class KindlePlugin extends Plugin {
       })
     );
 
-    this.app.workspace.onLayoutReady(() => {
+    this.app.workspace.onLayoutReady(async () => {
+    if (get(settingsStore).syncOnBoot) {
+      await this.startAmazonSync();
+    }
       ee.emit('obsidianReady');
     });
   }


### PR DESCRIPTION
https://github.com/hadynz/obsidian-kindle-plugin/issues/301

Selecting the "Sync on startup" setting and restarting Obsidian results in a "taking a long time to load" error. Currently the only workaround is to open the vault in safe mode, disable the option, and restart Obsidian.

This change moves the syncOnBoot logic to an `onLayoutReady` callback as described in Obsidian's best practices guide:

https://docs.obsidian.md/plugins/guides/load-time

>**If you have code that you want to run at startup, where should it go?**
>For most cases, you will want to wrap your code inside a onLayoutReady callback. These callbacks are deferred and are only called after Obsidian finishes loading.

With this change, Obsidian is able to load the vault as expected, and the highlight sync is performed in the background without pressing the "Sync..." button.