### PR TITLE
Bracket

### DIFF
--- a/src/rendering/renderer/fileNameRenderer.spec.ts
+++ b/src/rendering/renderer/fileNameRenderer.spec.ts
@@ -1,8 +1,25 @@
 import type { Book, BookMetadata } from '~/models';
+import { settingsStore } from '~/store';
 
 import FileNameRenderer, { removeParenthesesFromText } from './fileNameRenderer';
 
 describe('FileNameRenderer', () => {
+  beforeEach(() => {
+    settingsStore.store.set({
+      amazonRegion: 'global',
+      highlightsFolder: '/',
+      lastSyncMode: 'amazon',
+      hasStartedSync: false,
+      isLoggedIn: false,
+      syncOnBoot: false,
+      downloadBookMetadata: true,
+      ignoredBooks: [],
+      removeParens: false,
+      removeParensWhitelist: '',
+      removeParensType: 'all',
+    });
+  });
+
   describe('validate', () => {
     it('should return true for valid template', () => {
       const renderer = new FileNameRenderer('');
@@ -205,63 +222,110 @@ describe('FileNameRenderer', () => {
       const result = renderer.render(book, metadata);
       expect(result).not.toContain('?');
     });
+
+    it('removes bracket content from both title and author when enabled', () => {
+      settingsStore.actions.setRemoveParens(true);
+      settingsStore.actions.setRemoveParensType('all');
+
+      const book: Partial<Book> = {
+        title: 'Deep Work (Updated Edition)',
+        author: 'Cal Newport（Author）',
+      };
+      const metadata: Partial<BookMetadata> = {};
+
+      const renderer = new FileNameRenderer('{{author}} - {{longTitle}}');
+      expect(renderer.render(book, metadata)).toBe('Cal Newport - Deep Work.md');
+    });
+
+    it('skips bracket cleanup for whitelisted book titles', () => {
+      settingsStore.actions.setRemoveParens(true);
+      settingsStore.actions.setRemoveParensWhitelist('Deep Work');
+
+      const book: Partial<Book> = {
+        title: 'Deep Work (Updated Edition)',
+        author: 'Cal Newport (Author)',
+      };
+      const metadata: Partial<BookMetadata> = {};
+
+      const renderer = new FileNameRenderer('{{author}} - {{longTitle}}');
+      expect(renderer.render(book, metadata)).toBe(
+        'Cal Newport (Author) - Deep Work (Updated Edition).md'
+      );
+    });
+
+    it('matches whitelist entries case-insensitively and skips title and author cleanup together', () => {
+      settingsStore.actions.setRemoveParens(true);
+      settingsStore.actions.setRemoveParensWhitelist('deep work');
+
+      const book: Partial<Book> = {
+        title: 'Deep Work (Updated Edition)',
+        author: 'Cal Newport (Author)',
+      };
+      const metadata: Partial<BookMetadata> = {};
+
+      const renderer = new FileNameRenderer('{{author}} - {{longTitle}}');
+      expect(renderer.render(book, metadata)).toBe(
+        'Cal Newport (Author) - Deep Work (Updated Edition).md'
+      );
+    });
   });
 });
 
 describe('removeParenthesesFromText', () => {
   it('removes English parentheses', () => {
-    expect(removeParenthesesFromText('Title (Subtitle)', 'english', true)).toBe('Title');
-    expect(removeParenthesesFromText('Title (Subtitle)', 'all', true)).toBe('Title');
+    expect(removeParenthesesFromText('Title (Subtitle)', 'english')).toBe('Title');
+    expect(removeParenthesesFromText('Title (Subtitle)', 'all')).toBe('Title');
   });
 
   it('removes Chinese parentheses', () => {
-    expect(removeParenthesesFromText('Title（Subtitle）', 'chinese', true)).toBe('Title');
-    expect(removeParenthesesFromText('Title（Subtitle）', 'all', true)).toBe('Title');
+    expect(removeParenthesesFromText('Title（Subtitle）', 'chinese')).toBe('Title');
+    expect(removeParenthesesFromText('Title（Subtitle）', 'all')).toBe('Title');
   });
 
-  it('handles spaces correctly when removing English parentheses', () => {
-    // With space removal
-    expect(removeParenthesesFromText('Title (Subtitle)', 'english', true)).toBe('Title');
-    expect(removeParenthesesFromText('Title  (Subtitle)', 'english', true)).toBe('Title');
-
-    // Without space removal
-    expect(removeParenthesesFromText('Title (Subtitle)', 'english', false)).toBe('Title');
+  it('always cleans up spaces around removed English brackets', () => {
+    expect(removeParenthesesFromText('Title (Subtitle)', 'english')).toBe('Title');
+    expect(removeParenthesesFromText('Title  (Subtitle)', 'english')).toBe('Title');
   });
 
   it('removes nested parentheses', () => {
     // Nested English
-    expect(removeParenthesesFromText('Title (Subtitle (Extra))', 'english', true)).toBe('Title');
+    expect(removeParenthesesFromText('Title (Subtitle (Extra))', 'english')).toBe('Title');
 
     // Nested Chinese
-    expect(removeParenthesesFromText('Title（Subtitle（Extra））', 'chinese', true)).toBe('Title');
+    expect(removeParenthesesFromText('Title（Subtitle（Extra））', 'chinese')).toBe('Title');
 
     // Mixed nested
-    expect(removeParenthesesFromText('Title (Subtitle（Extra）)', 'all', true)).toBe('Title');
-    expect(removeParenthesesFromText('Title（Subtitle (Extra)）', 'all', true)).toBe('Title');
+    expect(removeParenthesesFromText('Title (Subtitle（Extra）)', 'all')).toBe('Title');
+    expect(removeParenthesesFromText('Title（Subtitle (Extra)）', 'all')).toBe('Title');
   });
 
   it('respects parenthesis type setting', () => {
     const text = 'Title (English)（Chinese）';
 
     // Remove only English
-    expect(removeParenthesesFromText(text, 'english', true)).toBe('Title （Chinese）');
+    expect(removeParenthesesFromText(text, 'english')).toBe('Title （Chinese）');
 
     // Remove only Chinese
-    expect(removeParenthesesFromText(text, 'chinese', true)).toBe('Title (English)');
+    expect(removeParenthesesFromText(text, 'chinese')).toBe('Title (English)');
 
     // Remove all
-    expect(removeParenthesesFromText(text, 'all', true)).toBe('Title');
+    expect(removeParenthesesFromText(text, 'all')).toBe('Title');
   });
 
   it('handles edge cases', () => {
     // Empty string result -> returns original
-    expect(removeParenthesesFromText('(Parens Only)', 'english', true)).toBe('(Parens Only)');
-    expect(removeParenthesesFromText('（Parens Only）', 'chinese', true)).toBe('（Parens Only）');
+    expect(removeParenthesesFromText('(Parens Only)', 'english')).toBe('(Parens Only)');
+    expect(removeParenthesesFromText('（Parens Only）', 'chinese')).toBe('（Parens Only）');
 
     // No parentheses
-    expect(removeParenthesesFromText('Title', 'all', true)).toBe('Title');
+    expect(removeParenthesesFromText('Title', 'all')).toBe('Title');
 
     // Multiple separate parentheses
-    expect(removeParenthesesFromText('Title (One) (Two)', 'english', true)).toBe('Title');
+    expect(removeParenthesesFromText('Title (One) (Two)', 'english')).toBe('Title');
+  });
+
+  it('returns original text when removal would produce an empty string', () => {
+    expect(removeParenthesesFromText('()', 'english')).toBe('()');
+    expect(removeParenthesesFromText('（ ）', 'chinese')).toBe('（ ）');
   });
 });

--- a/src/rendering/renderer/fileNameRenderer.spec.ts
+++ b/src/rendering/renderer/fileNameRenderer.spec.ts
@@ -16,7 +16,6 @@ describe('FileNameRenderer', () => {
       ignoredBooks: [],
       removeParens: false,
       removeParensWhitelist: '',
-      removeParensType: 'all',
     });
   });
 
@@ -225,7 +224,6 @@ describe('FileNameRenderer', () => {
 
     it('removes bracket content from both title and author when enabled', () => {
       settingsStore.actions.setRemoveParens(true);
-      settingsStore.actions.setRemoveParensType('all');
 
       const book: Partial<Book> = {
         title: 'Deep Work (Updated Edition)',
@@ -273,59 +271,48 @@ describe('FileNameRenderer', () => {
 
 describe('removeParenthesesFromText', () => {
   it('removes English parentheses', () => {
-    expect(removeParenthesesFromText('Title (Subtitle)', 'english')).toBe('Title');
-    expect(removeParenthesesFromText('Title (Subtitle)', 'all')).toBe('Title');
+    expect(removeParenthesesFromText('Title (Subtitle)')).toBe('Title');
   });
 
   it('removes Chinese parentheses', () => {
-    expect(removeParenthesesFromText('Title（Subtitle）', 'chinese')).toBe('Title');
-    expect(removeParenthesesFromText('Title（Subtitle）', 'all')).toBe('Title');
+    expect(removeParenthesesFromText('Title（Subtitle）')).toBe('Title');
   });
 
   it('always cleans up spaces around removed English brackets', () => {
-    expect(removeParenthesesFromText('Title (Subtitle)', 'english')).toBe('Title');
-    expect(removeParenthesesFromText('Title  (Subtitle)', 'english')).toBe('Title');
+    expect(removeParenthesesFromText('Title (Subtitle)')).toBe('Title');
+    expect(removeParenthesesFromText('Title  (Subtitle)')).toBe('Title');
   });
 
   it('removes nested parentheses', () => {
     // Nested English
-    expect(removeParenthesesFromText('Title (Subtitle (Extra))', 'english')).toBe('Title');
+    expect(removeParenthesesFromText('Title (Subtitle (Extra))')).toBe('Title');
 
     // Nested Chinese
-    expect(removeParenthesesFromText('Title（Subtitle（Extra））', 'chinese')).toBe('Title');
+    expect(removeParenthesesFromText('Title（Subtitle（Extra））')).toBe('Title');
 
     // Mixed nested
-    expect(removeParenthesesFromText('Title (Subtitle（Extra）)', 'all')).toBe('Title');
-    expect(removeParenthesesFromText('Title（Subtitle (Extra)）', 'all')).toBe('Title');
+    expect(removeParenthesesFromText('Title (Subtitle（Extra）)')).toBe('Title');
+    expect(removeParenthesesFromText('Title（Subtitle (Extra)）')).toBe('Title');
   });
 
-  it('respects parenthesis type setting', () => {
-    const text = 'Title (English)（Chinese）';
-
-    // Remove only English
-    expect(removeParenthesesFromText(text, 'english')).toBe('Title （Chinese）');
-
-    // Remove only Chinese
-    expect(removeParenthesesFromText(text, 'chinese')).toBe('Title (English)');
-
-    // Remove all
-    expect(removeParenthesesFromText(text, 'all')).toBe('Title');
+  it('removes English and Chinese brackets together', () => {
+    expect(removeParenthesesFromText('Title (English)（Chinese）')).toBe('Title');
   });
 
   it('handles edge cases', () => {
     // Empty string result -> returns original
-    expect(removeParenthesesFromText('(Parens Only)', 'english')).toBe('(Parens Only)');
-    expect(removeParenthesesFromText('（Parens Only）', 'chinese')).toBe('（Parens Only）');
+    expect(removeParenthesesFromText('(Parens Only)')).toBe('(Parens Only)');
+    expect(removeParenthesesFromText('（Parens Only）')).toBe('（Parens Only）');
 
     // No parentheses
-    expect(removeParenthesesFromText('Title', 'all')).toBe('Title');
+    expect(removeParenthesesFromText('Title')).toBe('Title');
 
     // Multiple separate parentheses
-    expect(removeParenthesesFromText('Title (One) (Two)', 'english')).toBe('Title');
+    expect(removeParenthesesFromText('Title (One) (Two)')).toBe('Title');
   });
 
   it('returns original text when removal would produce an empty string', () => {
-    expect(removeParenthesesFromText('()', 'english')).toBe('()');
-    expect(removeParenthesesFromText('（ ）', 'chinese')).toBe('（ ）');
+    expect(removeParenthesesFromText('()')).toBe('()');
+    expect(removeParenthesesFromText('（ ）')).toBe('（ ）');
   });
 });

--- a/src/rendering/renderer/fileNameRenderer.spec.ts
+++ b/src/rendering/renderer/fileNameRenderer.spec.ts
@@ -1,6 +1,6 @@
 import type { Book, BookMetadata } from '~/models';
 
-import FileNameRenderer from './fileNameRenderer';
+import FileNameRenderer, { removeParenthesesFromText } from './fileNameRenderer';
 
 describe('FileNameRenderer', () => {
   describe('validate', () => {
@@ -205,5 +205,63 @@ describe('FileNameRenderer', () => {
       const result = renderer.render(book, metadata);
       expect(result).not.toContain('?');
     });
+  });
+});
+
+describe('removeParenthesesFromText', () => {
+  it('removes English parentheses', () => {
+    expect(removeParenthesesFromText('Title (Subtitle)', 'english', true)).toBe('Title');
+    expect(removeParenthesesFromText('Title (Subtitle)', 'all', true)).toBe('Title');
+  });
+
+  it('removes Chinese parentheses', () => {
+    expect(removeParenthesesFromText('Title（Subtitle）', 'chinese', true)).toBe('Title');
+    expect(removeParenthesesFromText('Title（Subtitle）', 'all', true)).toBe('Title');
+  });
+
+  it('handles spaces correctly when removing English parentheses', () => {
+    // With space removal
+    expect(removeParenthesesFromText('Title (Subtitle)', 'english', true)).toBe('Title');
+    expect(removeParenthesesFromText('Title  (Subtitle)', 'english', true)).toBe('Title');
+
+    // Without space removal
+    expect(removeParenthesesFromText('Title (Subtitle)', 'english', false)).toBe('Title');
+  });
+
+  it('removes nested parentheses', () => {
+    // Nested English
+    expect(removeParenthesesFromText('Title (Subtitle (Extra))', 'english', true)).toBe('Title');
+
+    // Nested Chinese
+    expect(removeParenthesesFromText('Title（Subtitle（Extra））', 'chinese', true)).toBe('Title');
+
+    // Mixed nested
+    expect(removeParenthesesFromText('Title (Subtitle（Extra）)', 'all', true)).toBe('Title');
+    expect(removeParenthesesFromText('Title（Subtitle (Extra)）', 'all', true)).toBe('Title');
+  });
+
+  it('respects parenthesis type setting', () => {
+    const text = 'Title (English)（Chinese）';
+
+    // Remove only English
+    expect(removeParenthesesFromText(text, 'english', true)).toBe('Title （Chinese）');
+
+    // Remove only Chinese
+    expect(removeParenthesesFromText(text, 'chinese', true)).toBe('Title (English)');
+
+    // Remove all
+    expect(removeParenthesesFromText(text, 'all', true)).toBe('Title');
+  });
+
+  it('handles edge cases', () => {
+    // Empty string result -> returns original
+    expect(removeParenthesesFromText('(Parens Only)', 'english', true)).toBe('(Parens Only)');
+    expect(removeParenthesesFromText('（Parens Only）', 'chinese', true)).toBe('（Parens Only）');
+
+    // No parentheses
+    expect(removeParenthesesFromText('Title', 'all', true)).toBe('Title');
+
+    // Multiple separate parentheses
+    expect(removeParenthesesFromText('Title (One) (Two)', 'english', true)).toBe('Title');
   });
 });

--- a/src/rendering/renderer/fileNameRenderer.ts
+++ b/src/rendering/renderer/fileNameRenderer.ts
@@ -52,7 +52,7 @@ export default class FileNameRenderer {
   public render(book: Partial<Book>, metadata: Partial<BookMetadata>): string {
     const settings = get(settingsStore);
 
-    // Apply bracket removal to title if enabled
+    // Apply bracket removal to title and/or author if enabled
     const processedBook = { ...book };
     if (settings.removeParens) {
       const whitelist = settings.removeParensWhitelist
@@ -60,7 +60,22 @@ export default class FileNameRenderer {
         .map((line: string) => line.trim())
         .filter((line: string) => line !== '');
 
-      processedBook.title = this.removeParentheses(processedBook.title ?? '', whitelist);
+      if (settings.removeParensFromTitle) {
+        processedBook.title = this.removeParenthesesFromText(
+          processedBook.title ?? '',
+          whitelist,
+          settings.removeParensType,
+          settings.removeParensSpaces
+        );
+      }
+      if (settings.removeParensFromAuthor) {
+        processedBook.author = this.removeParenthesesFromText(
+          processedBook.author ?? '',
+          whitelist,
+          settings.removeParensType,
+          settings.removeParensSpaces
+        );
+      }
     }
 
     const templateVariables = fileNameTemplateVariables(processedBook, metadata);
@@ -73,10 +88,15 @@ export default class FileNameRenderer {
   }
 
   /**
-   * Remove parenthetical content (both Chinese and English brackets) from text.
+   * Remove parenthetical content from text based on bracket type settings.
    * Handles nested brackets by running multiple passes.
    */
-  private removeParentheses(text: string, whitelist: string[]): string {
+  private removeParenthesesFromText(
+    text: string,
+    whitelist: string[],
+    removeParensType: 'all' | 'chinese' | 'english',
+    removeParensSpaces: boolean
+  ): string {
     // Skip if text matches any whitelist keyword
     if (whitelist.some((keyword) => text.includes(keyword))) {
       return text;
@@ -84,13 +104,23 @@ export default class FileNameRenderer {
 
     let result = text;
 
-    // Remove all types of brackets (Chinese （） and English ()) with content
     // Loop to handle nested brackets
     let prev = '';
     while (prev !== result) {
       prev = result;
-      result = result.replace(/（[^（）]*）/g, '');
-      result = result.replace(/\([^()]*\)/g, '');
+
+      if (removeParensType === 'chinese' || removeParensType === 'all') {
+        result = result.replace(/（[^（）]*）/g, '');
+      }
+
+      if (removeParensType === 'english' || removeParensType === 'all') {
+        if (removeParensSpaces) {
+          // Remove English brackets and surrounding spaces, avoiding double spaces
+          result = result.replace(/\s*\([^()]*\)\s*/g, ' ');
+        } else {
+          result = result.replace(/\([^()]*\)/g, '');
+        }
+      }
     }
 
     // Collapse multiple spaces and trim

--- a/src/rendering/renderer/fileNameRenderer.ts
+++ b/src/rendering/renderer/fileNameRenderer.ts
@@ -65,14 +65,8 @@ export default class FileNameRenderer {
       const isWhitelisted = whitelist.some((keyword) => titleLower.includes(keyword));
 
       if (!isWhitelisted) {
-        processedBook.title = removeParenthesesFromText(
-          processedBook.title ?? '',
-          settings.removeParensType
-        );
-        processedBook.author = removeParenthesesFromText(
-          processedBook.author ?? '',
-          settings.removeParensType
-        );
+        processedBook.title = removeParenthesesFromText(processedBook.title ?? '');
+        processedBook.author = removeParenthesesFromText(processedBook.author ?? '');
       }
     }
 
@@ -87,14 +81,11 @@ export default class FileNameRenderer {
 }
 
 /**
- * Remove parenthetical content from text based on bracket type settings.
+ * Remove English and Chinese bracketed content from text.
  * Handles nested brackets by running multiple passes.
  * Returns original text if removal would result in an empty string.
  */
-export const removeParenthesesFromText = (
-  text: string,
-  removeParensType: 'all' | 'chinese' | 'english'
-): string => {
+export const removeParenthesesFromText = (text: string): string => {
   let result = text;
 
   // Loop to handle nested brackets
@@ -102,14 +93,10 @@ export const removeParenthesesFromText = (
   while (prev !== result) {
     prev = result;
 
-    if (removeParensType === 'chinese' || removeParensType === 'all') {
-      result = result.replace(/（[^（）]*）/g, '');
-    }
+    result = result.replace(/（[^（）]*）/g, '');
 
-    if (removeParensType === 'english' || removeParensType === 'all') {
-      // Remove English brackets and surrounding spaces, avoiding double spaces.
-      result = result.replace(/\s*\([^()]*\)\s*/g, ' ');
-    }
+    // Remove English brackets and surrounding spaces, avoiding double spaces.
+    result = result.replace(/\s*\([^()]*\)\s*/g, ' ');
   }
 
   // Collapse multiple spaces and trim

--- a/src/rendering/renderer/fileNameRenderer.ts
+++ b/src/rendering/renderer/fileNameRenderer.ts
@@ -1,7 +1,9 @@
 import nunjucks, { Environment } from 'nunjucks';
 import sanitize from 'sanitize-filename';
+import { get } from 'svelte/store';
 
 import type { Book, BookMetadata } from '~/models';
+import { settingsStore } from '~/store';
 
 import { fileNameTemplateVariables } from './templateVariables';
 
@@ -48,12 +50,52 @@ export default class FileNameRenderer {
   }
 
   public render(book: Partial<Book>, metadata: Partial<BookMetadata>): string {
-    const templateVariables = fileNameTemplateVariables(book, metadata);
+    const settings = get(settingsStore);
+
+    // Apply bracket removal to title if enabled
+    const processedBook = { ...book };
+    if (settings.removeParens) {
+      const whitelist = settings.removeParensWhitelist
+        .split('\n')
+        .map((line: string) => line.trim())
+        .filter((line: string) => line !== '');
+
+      processedBook.title = this.removeParentheses(processedBook.title ?? '', whitelist);
+    }
+
+    const templateVariables = fileNameTemplateVariables(processedBook, metadata);
 
     const rendered = this.nunjucks.renderString(this.template, templateVariables);
 
     const fileName = sanitizeForObsidian(rendered);
 
     return `${fileName}.md`;
+  }
+
+  /**
+   * Remove parenthetical content (both Chinese and English brackets) from text.
+   * Handles nested brackets by running multiple passes.
+   */
+  private removeParentheses(text: string, whitelist: string[]): string {
+    // Skip if text matches any whitelist keyword
+    if (whitelist.some((keyword) => text.includes(keyword))) {
+      return text;
+    }
+
+    let result = text;
+
+    // Remove all types of brackets (Chinese （） and English ()) with content
+    // Loop to handle nested brackets
+    let prev = '';
+    while (prev !== result) {
+      prev = result;
+      result = result.replace(/（[^（）]*）/g, '');
+      result = result.replace(/\([^()]*\)/g, '');
+    }
+
+    // Collapse multiple spaces and trim
+    result = result.replace(/ {2,}/g, ' ').trim();
+
+    return result;
   }
 }

--- a/src/rendering/renderer/fileNameRenderer.ts
+++ b/src/rendering/renderer/fileNameRenderer.ts
@@ -57,24 +57,28 @@ export default class FileNameRenderer {
     if (settings.removeParens) {
       const whitelist = settings.removeParensWhitelist
         .split('\n')
-        .map((line: string) => line.trim())
+        .map((line: string) => line.trim().toLowerCase())
         .filter((line: string) => line !== '');
 
-      if (settings.removeParensFromTitle) {
-        processedBook.title = this.removeParenthesesFromText(
-          processedBook.title ?? '',
-          whitelist,
-          settings.removeParensType,
-          settings.removeParensSpaces
-        );
-      }
-      if (settings.removeParensFromAuthor) {
-        processedBook.author = this.removeParenthesesFromText(
-          processedBook.author ?? '',
-          whitelist,
-          settings.removeParensType,
-          settings.removeParensSpaces
-        );
+      // Check whitelist against book title once — skip all processing if matched
+      const titleLower = (processedBook.title ?? '').toLowerCase();
+      const isWhitelisted = whitelist.some((keyword) => titleLower.includes(keyword));
+
+      if (!isWhitelisted) {
+        if (settings.removeParensFromTitle) {
+          processedBook.title = removeParenthesesFromText(
+            processedBook.title ?? '',
+            settings.removeParensType,
+            settings.removeParensSpaces
+          );
+        }
+        if (settings.removeParensFromAuthor) {
+          processedBook.author = removeParenthesesFromText(
+            processedBook.author ?? '',
+            settings.removeParensType,
+            settings.removeParensSpaces
+          );
+        }
       }
     }
 
@@ -129,3 +133,41 @@ export default class FileNameRenderer {
     return result;
   }
 }
+
+/**
+ * Remove parenthetical content from text based on bracket type settings.
+ * Handles nested brackets by running multiple passes.
+ * Returns original text if removal would result in an empty string.
+ */
+export const removeParenthesesFromText = (
+  text: string,
+  removeParensType: 'all' | 'chinese' | 'english',
+  removeParensSpaces: boolean
+): string => {
+  let result = text;
+
+  // Loop to handle nested brackets
+  let prev = '';
+  while (prev !== result) {
+    prev = result;
+
+    if (removeParensType === 'chinese' || removeParensType === 'all') {
+      result = result.replace(/（[^（）]*）/g, '');
+    }
+
+    if (removeParensType === 'english' || removeParensType === 'all') {
+      if (removeParensSpaces) {
+        // Remove English brackets and surrounding spaces, avoiding double spaces
+        result = result.replace(/\s*\([^()]*\)\s*/g, ' ');
+      } else {
+        result = result.replace(/\([^()]*\)/g, '');
+      }
+    }
+  }
+
+  // Collapse multiple spaces and trim
+  result = result.replace(/ {2,}/g, ' ').trim();
+
+  // Return original text if removal resulted in empty string
+  return result || text;
+};

--- a/src/rendering/renderer/fileNameRenderer.ts
+++ b/src/rendering/renderer/fileNameRenderer.ts
@@ -52,7 +52,7 @@ export default class FileNameRenderer {
   public render(book: Partial<Book>, metadata: Partial<BookMetadata>): string {
     const settings = get(settingsStore);
 
-    // Apply bracket removal to title and/or author if enabled
+    // Apply bracket removal to filename-relevant book fields if enabled.
     const processedBook = { ...book };
     if (settings.removeParens) {
       const whitelist = settings.removeParensWhitelist
@@ -65,20 +65,14 @@ export default class FileNameRenderer {
       const isWhitelisted = whitelist.some((keyword) => titleLower.includes(keyword));
 
       if (!isWhitelisted) {
-        if (settings.removeParensFromTitle) {
-          processedBook.title = removeParenthesesFromText(
-            processedBook.title ?? '',
-            settings.removeParensType,
-            settings.removeParensSpaces
-          );
-        }
-        if (settings.removeParensFromAuthor) {
-          processedBook.author = removeParenthesesFromText(
-            processedBook.author ?? '',
-            settings.removeParensType,
-            settings.removeParensSpaces
-          );
-        }
+        processedBook.title = removeParenthesesFromText(
+          processedBook.title ?? '',
+          settings.removeParensType
+        );
+        processedBook.author = removeParenthesesFromText(
+          processedBook.author ?? '',
+          settings.removeParensType
+        );
       }
     }
 
@@ -90,48 +84,6 @@ export default class FileNameRenderer {
 
     return `${fileName}.md`;
   }
-
-  /**
-   * Remove parenthetical content from text based on bracket type settings.
-   * Handles nested brackets by running multiple passes.
-   */
-  private removeParenthesesFromText(
-    text: string,
-    whitelist: string[],
-    removeParensType: 'all' | 'chinese' | 'english',
-    removeParensSpaces: boolean
-  ): string {
-    // Skip if text matches any whitelist keyword
-    if (whitelist.some((keyword) => text.includes(keyword))) {
-      return text;
-    }
-
-    let result = text;
-
-    // Loop to handle nested brackets
-    let prev = '';
-    while (prev !== result) {
-      prev = result;
-
-      if (removeParensType === 'chinese' || removeParensType === 'all') {
-        result = result.replace(/（[^（）]*）/g, '');
-      }
-
-      if (removeParensType === 'english' || removeParensType === 'all') {
-        if (removeParensSpaces) {
-          // Remove English brackets and surrounding spaces, avoiding double spaces
-          result = result.replace(/\s*\([^()]*\)\s*/g, ' ');
-        } else {
-          result = result.replace(/\([^()]*\)/g, '');
-        }
-      }
-    }
-
-    // Collapse multiple spaces and trim
-    result = result.replace(/ {2,}/g, ' ').trim();
-
-    return result;
-  }
 }
 
 /**
@@ -141,8 +93,7 @@ export default class FileNameRenderer {
  */
 export const removeParenthesesFromText = (
   text: string,
-  removeParensType: 'all' | 'chinese' | 'english',
-  removeParensSpaces: boolean
+  removeParensType: 'all' | 'chinese' | 'english'
 ): string => {
   let result = text;
 
@@ -156,12 +107,8 @@ export const removeParenthesesFromText = (
     }
 
     if (removeParensType === 'english' || removeParensType === 'all') {
-      if (removeParensSpaces) {
-        // Remove English brackets and surrounding spaces, avoiding double spaces
-        result = result.replace(/\s*\([^()]*\)\s*/g, ' ');
-      } else {
-        result = result.replace(/\([^()]*\)/g, '');
-      }
+      // Remove English brackets and surrounding spaces, avoiding double spaces.
+      result = result.replace(/\s*\([^()]*\)\s*/g, ' ');
     }
   }
 

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -187,9 +187,9 @@ export class SettingsTab extends PluginSettingTab {
 
   private removeParentheses(): void {
     new Setting(this.containerEl)
-      .setName('Remove bracket content from book info')
+      .setName('Remove parentheses content from book info')
       .setDesc(
-        'Automatically remove content within brackets from book titles and/or author names when generating file names'
+        'Automatically remove content within parentheses from book titles and/or author names when generating file names'
       )
       .addToggle((toggle) =>
         toggle.setValue(get(settingsStore).removeParens).onChange((value) => {
@@ -200,14 +200,14 @@ export class SettingsTab extends PluginSettingTab {
 
     // Only show sub-settings when removeParens is enabled
     if (get(settingsStore).removeParens) {
-      // Create a collapsible details section for bracket settings
-      const detailsEl = this.containerEl.createEl('details', { cls: 'bracket-settings' });
-      detailsEl.createEl('summary', { text: 'Bracket removal settings' });
+      // Create a collapsible details section for parentheses settings
+      const detailsEl = this.containerEl.createEl('details', { cls: 'parentheses-settings' });
+      detailsEl.createEl('summary', { text: 'Parentheses removal settings' });
 
       // Title toggle
       new Setting(detailsEl)
         .setName('Remove from title')
-        .setDesc('Remove bracket content from book titles')
+        .setDesc('Remove parentheses content from book titles')
         .addToggle((toggle) =>
           toggle.setValue(get(settingsStore).removeParensFromTitle).onChange((value) => {
             settingsStore.actions.setRemoveParensFromTitle(value);
@@ -217,22 +217,22 @@ export class SettingsTab extends PluginSettingTab {
       // Author toggle
       new Setting(detailsEl)
         .setName('Remove from author')
-        .setDesc('Remove bracket content from author names')
+        .setDesc('Remove parentheses content from author names')
         .addToggle((toggle) =>
           toggle.setValue(get(settingsStore).removeParensFromAuthor).onChange((value) => {
             settingsStore.actions.setRemoveParensFromAuthor(value);
           })
         );
 
-      // Bracket type dropdown
+      // Parentheses type dropdown
       new Setting(detailsEl)
-        .setName('Bracket type')
-        .setDesc('Choose which types of brackets to remove')
+        .setName('Parentheses type')
+        .setDesc('Choose which types of parentheses to remove')
         .addDropdown((dropdown) => {
           dropdown
-            .addOption('all', 'All types (\uFF08\uFF09 + ())')
-            .addOption('chinese', 'Chinese brackets only (\uFF08\uFF09)')
-            .addOption('english', 'English brackets only (())')
+            .addOption('all', 'All types (（） + ())')
+            .addOption('chinese', 'Chinese parentheses only (（）)')
+            .addOption('english', 'English parentheses only (())')
             .setValue(get(settingsStore).removeParensType)
             .onChange((value: 'all' | 'chinese' | 'english') => {
               settingsStore.actions.setRemoveParensType(value);
@@ -244,9 +244,9 @@ export class SettingsTab extends PluginSettingTab {
       const parensType = get(settingsStore).removeParensType;
       if (parensType === 'english' || parensType === 'all') {
         new Setting(detailsEl)
-          .setName('Remove spaces around English brackets')
+          .setName('Remove spaces around English parentheses')
           .setDesc(
-            'Clean up extra spaces when removing English brackets (e.g. "Tom Mitchell (CMU)" → "Tom Mitchell")'
+            'Clean up extra spaces when removing English parentheses (e.g. "Tom Mitchell (CMU)" → "Tom Mitchell")'
           )
           .addToggle((toggle) =>
             toggle.setValue(get(settingsStore).removeParensSpaces).onChange((value) => {
@@ -257,9 +257,9 @@ export class SettingsTab extends PluginSettingTab {
 
       // Whitelist
       new Setting(detailsEl)
-        .setName('Bracket removal whitelist')
+        .setName('Parentheses removal whitelist')
         .setDesc(
-          'Books with titles containing any of these keywords will skip bracket removal. One keyword per line.'
+          'Books with titles containing any of these keywords will skip parentheses removal. One keyword per line.'
         )
         .addTextArea((textArea) => {
           textArea

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -198,26 +198,8 @@ export class SettingsTab extends PluginSettingTab {
         })
       );
 
-    // Only show sub-settings when removeParens is enabled
     if (get(settingsStore).removeParens) {
-      const detailsEl = this.containerEl.createEl('details', { cls: 'bracket-settings' });
-      detailsEl.createEl('summary', { text: 'Bracket cleanup settings' });
-
-      new Setting(detailsEl)
-        .setName('Bracket type')
-        .setDesc('Choose which bracket styles to remove from titles and authors')
-        .addDropdown((dropdown) => {
-          dropdown
-            .addOption('all', 'All brackets (（） + ())')
-            .addOption('chinese', 'Full-width brackets only (（）)')
-            .addOption('english', 'Half-width brackets only (())')
-            .setValue(get(settingsStore).removeParensType)
-            .onChange((value: 'all' | 'chinese' | 'english') => {
-              settingsStore.actions.setRemoveParensType(value);
-            });
-        });
-
-      new Setting(detailsEl)
+      new Setting(this.containerEl)
         .setName('Bracket cleanup whitelist')
         .setDesc(
           'Books with titles containing any of these keywords will skip bracket cleanup for both title and author. One keyword per line, case-insensitive.'

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -187,27 +187,83 @@ export class SettingsTab extends PluginSettingTab {
 
   private removeParentheses(): void {
     new Setting(this.containerEl)
-      .setName('Remove parenthetical content from book info')
+      .setName('Remove bracket content from book info')
       .setDesc(
-        'Automatically remove content within parentheses from book titles when generating file names'
+        'Automatically remove content within brackets from book titles and/or author names when generating file names'
       )
       .addToggle((toggle) =>
         toggle.setValue(get(settingsStore).removeParens).onChange((value) => {
           settingsStore.actions.setRemoveParens(value);
-          this.display(); // Re-render to show/hide whitelist
+          this.display(); // Re-render to show/hide sub-settings
         })
       );
 
-    // Only show whitelist when removeParens is enabled
+    // Only show sub-settings when removeParens is enabled
     if (get(settingsStore).removeParens) {
-      new Setting(this.containerEl)
-        .setName('Parentheses removal whitelist')
+      // Create a collapsible details section for bracket settings
+      const detailsEl = this.containerEl.createEl('details', { cls: 'bracket-settings' });
+      detailsEl.createEl('summary', { text: 'Bracket removal settings' });
+
+      // Title toggle
+      new Setting(detailsEl)
+        .setName('Remove from title')
+        .setDesc('Remove bracket content from book titles')
+        .addToggle((toggle) =>
+          toggle.setValue(get(settingsStore).removeParensFromTitle).onChange((value) => {
+            settingsStore.actions.setRemoveParensFromTitle(value);
+          })
+        );
+
+      // Author toggle
+      new Setting(detailsEl)
+        .setName('Remove from author')
+        .setDesc('Remove bracket content from author names')
+        .addToggle((toggle) =>
+          toggle.setValue(get(settingsStore).removeParensFromAuthor).onChange((value) => {
+            settingsStore.actions.setRemoveParensFromAuthor(value);
+          })
+        );
+
+      // Bracket type dropdown
+      new Setting(detailsEl)
+        .setName('Bracket type')
+        .setDesc('Choose which types of brackets to remove')
+        .addDropdown((dropdown) => {
+          dropdown
+            .addOption('all', 'All types (\uFF08\uFF09 + ())')
+            .addOption('chinese', 'Chinese brackets only (\uFF08\uFF09)')
+            .addOption('english', 'English brackets only (())')
+            .setValue(get(settingsStore).removeParensType)
+            .onChange((value: 'all' | 'chinese' | 'english') => {
+              settingsStore.actions.setRemoveParensType(value);
+              this.display(); // Re-render to show/hide space option
+            });
+        });
+
+      // Space handling toggle (only for english or all modes)
+      const parensType = get(settingsStore).removeParensType;
+      if (parensType === 'english' || parensType === 'all') {
+        new Setting(detailsEl)
+          .setName('Remove spaces around English brackets')
+          .setDesc(
+            'Clean up extra spaces when removing English brackets (e.g. "Tom Mitchell (CMU)" → "Tom Mitchell")'
+          )
+          .addToggle((toggle) =>
+            toggle.setValue(get(settingsStore).removeParensSpaces).onChange((value) => {
+              settingsStore.actions.setRemoveParensSpaces(value);
+            })
+          );
+      }
+
+      // Whitelist
+      new Setting(detailsEl)
+        .setName('Bracket removal whitelist')
         .setDesc(
-          'Books with titles containing any of these keywords will skip parentheses removal. One keyword per line.'
+          'Books with titles containing any of these keywords will skip bracket removal. One keyword per line.'
         )
         .addTextArea((textArea) => {
           textArea
-            .setPlaceholder('e.g.\n魔法禁书目录')
+            .setPlaceholder('e.g.\n\u9B54\u6CD5\u7981\u4E66\u76EE\u5F55')
             .setValue(get(settingsStore).removeParensWhitelist)
             .onChange((value) => {
               settingsStore.actions.setRemoveParensWhitelist(value);

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -187,9 +187,9 @@ export class SettingsTab extends PluginSettingTab {
 
   private removeParentheses(): void {
     new Setting(this.containerEl)
-      .setName('Remove parentheses content from book info')
+      .setName('Remove bracket content from filename metadata')
       .setDesc(
-        'Automatically remove content within parentheses from book titles and/or author names when generating file names'
+        'Automatically remove bracketed content from book titles and authors before rendering file names'
       )
       .addToggle((toggle) =>
         toggle.setValue(get(settingsStore).removeParens).onChange((value) => {
@@ -200,70 +200,31 @@ export class SettingsTab extends PluginSettingTab {
 
     // Only show sub-settings when removeParens is enabled
     if (get(settingsStore).removeParens) {
-      // Create a collapsible details section for parentheses settings
-      const detailsEl = this.containerEl.createEl('details', { cls: 'parentheses-settings' });
-      detailsEl.createEl('summary', { text: 'Parentheses removal settings' });
+      const detailsEl = this.containerEl.createEl('details', { cls: 'bracket-settings' });
+      detailsEl.createEl('summary', { text: 'Bracket cleanup settings' });
 
-      // Title toggle
       new Setting(detailsEl)
-        .setName('Remove from title')
-        .setDesc('Remove parentheses content from book titles')
-        .addToggle((toggle) =>
-          toggle.setValue(get(settingsStore).removeParensFromTitle).onChange((value) => {
-            settingsStore.actions.setRemoveParensFromTitle(value);
-          })
-        );
-
-      // Author toggle
-      new Setting(detailsEl)
-        .setName('Remove from author')
-        .setDesc('Remove parentheses content from author names')
-        .addToggle((toggle) =>
-          toggle.setValue(get(settingsStore).removeParensFromAuthor).onChange((value) => {
-            settingsStore.actions.setRemoveParensFromAuthor(value);
-          })
-        );
-
-      // Parentheses type dropdown
-      new Setting(detailsEl)
-        .setName('Parentheses type')
-        .setDesc('Choose which types of parentheses to remove')
+        .setName('Bracket type')
+        .setDesc('Choose which bracket styles to remove from titles and authors')
         .addDropdown((dropdown) => {
           dropdown
-            .addOption('all', 'All types (（） + ())')
-            .addOption('chinese', 'Chinese parentheses only (（）)')
-            .addOption('english', 'English parentheses only (())')
+            .addOption('all', 'All brackets (（） + ())')
+            .addOption('chinese', 'Full-width brackets only (（）)')
+            .addOption('english', 'Half-width brackets only (())')
             .setValue(get(settingsStore).removeParensType)
             .onChange((value: 'all' | 'chinese' | 'english') => {
               settingsStore.actions.setRemoveParensType(value);
-              this.display(); // Re-render to show/hide space option
             });
         });
 
-      // Space handling toggle (only for english or all modes)
-      const parensType = get(settingsStore).removeParensType;
-      if (parensType === 'english' || parensType === 'all') {
-        new Setting(detailsEl)
-          .setName('Remove spaces around English parentheses')
-          .setDesc(
-            'Clean up extra spaces when removing English parentheses (e.g. "Tom Mitchell (CMU)" → "Tom Mitchell")'
-          )
-          .addToggle((toggle) =>
-            toggle.setValue(get(settingsStore).removeParensSpaces).onChange((value) => {
-              settingsStore.actions.setRemoveParensSpaces(value);
-            })
-          );
-      }
-
-      // Whitelist
       new Setting(detailsEl)
-        .setName('Parentheses removal whitelist')
+        .setName('Bracket cleanup whitelist')
         .setDesc(
-          'Books with titles containing any of these keywords will skip parentheses removal. One keyword per line.'
+          'Books with titles containing any of these keywords will skip bracket cleanup for both title and author. One keyword per line, case-insensitive.'
         )
         .addTextArea((textArea) => {
           textArea
-            .setPlaceholder('e.g.\n\u9B54\u6CD5\u7981\u4E66\u76EE\u5F55')
+            .setPlaceholder('e.g.\nWords of Radiance\nThe Pragmatic Programmer')
             .setValue(get(settingsStore).removeParensWhitelist)
             .onChange((value) => {
               settingsStore.actions.setRemoveParensWhitelist(value);

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -38,6 +38,7 @@ export class SettingsTab extends PluginSettingTab {
     this.amazonRegion();
     this.downloadBookMetadata();
     this.syncOnBoot();
+    this.removeParentheses();
     this.ignoredBooks();
     this.sponsorMe();
   }
@@ -182,6 +183,39 @@ export class SettingsTab extends PluginSettingTab {
         textArea.inputEl.rows = 6;
         textArea.inputEl.cols = 50;
       });
+  }
+
+  private removeParentheses(): void {
+    new Setting(this.containerEl)
+      .setName('Remove parenthetical content from book info')
+      .setDesc(
+        'Automatically remove content within parentheses from book titles when generating file names'
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(get(settingsStore).removeParens).onChange((value) => {
+          settingsStore.actions.setRemoveParens(value);
+          this.display(); // Re-render to show/hide whitelist
+        })
+      );
+
+    // Only show whitelist when removeParens is enabled
+    if (get(settingsStore).removeParens) {
+      new Setting(this.containerEl)
+        .setName('Parentheses removal whitelist')
+        .setDesc(
+          'Books with titles containing any of these keywords will skip parentheses removal. One keyword per line.'
+        )
+        .addTextArea((textArea) => {
+          textArea
+            .setPlaceholder('e.g.\n魔法禁书目录')
+            .setValue(get(settingsStore).removeParensWhitelist)
+            .onChange((value) => {
+              settingsStore.actions.setRemoveParensWhitelist(value);
+            });
+          textArea.inputEl.rows = 4;
+          textArea.inputEl.cols = 50;
+        });
+    }
   }
 
   private sponsorMe(): void {

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -19,7 +19,6 @@ type Settings = {
   ignoredBooks: string[];
   removeParens: boolean;
   removeParensWhitelist: string;
-  removeParensType: 'all' | 'chinese' | 'english';
 
   // Deprecated - delete eventually
   noteTemplate?: string;
@@ -37,7 +36,6 @@ const DEFAULT_SETTINGS: Settings = {
   ignoredBooks: [],
   removeParens: false,
   removeParensWhitelist: '',
-  removeParensType: 'all',
 };
 
 const createSettingsStore = () => {
@@ -174,13 +172,6 @@ const createSettingsStore = () => {
     });
   };
 
-  const setRemoveParensType = (value: 'all' | 'chinese' | 'english') => {
-    store.update((state) => {
-      state.removeParensType = value;
-      return state;
-    });
-  };
-
   return {
     store,
     subscribe: store.subscribe,
@@ -198,7 +189,6 @@ const createSettingsStore = () => {
       setIgnoredBooks,
       setRemoveParens,
       setRemoveParensWhitelist,
-      setRemoveParensType,
     },
   };
 };

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -19,6 +19,10 @@ type Settings = {
   ignoredBooks: string[];
   removeParens: boolean;
   removeParensWhitelist: string;
+  removeParensType: 'all' | 'chinese' | 'english';
+  removeParensSpaces: boolean;
+  removeParensFromTitle: boolean;
+  removeParensFromAuthor: boolean;
 
   // Deprecated - delete eventually
   noteTemplate?: string;
@@ -36,6 +40,10 @@ const DEFAULT_SETTINGS: Settings = {
   ignoredBooks: [],
   removeParens: false,
   removeParensWhitelist: '',
+  removeParensType: 'all',
+  removeParensSpaces: true,
+  removeParensFromTitle: true,
+  removeParensFromAuthor: false,
 };
 
 const createSettingsStore = () => {
@@ -172,6 +180,34 @@ const createSettingsStore = () => {
     });
   };
 
+  const setRemoveParensType = (value: 'all' | 'chinese' | 'english') => {
+    store.update((state) => {
+      state.removeParensType = value;
+      return state;
+    });
+  };
+
+  const setRemoveParensSpaces = (value: boolean) => {
+    store.update((state) => {
+      state.removeParensSpaces = value;
+      return state;
+    });
+  };
+
+  const setRemoveParensFromTitle = (value: boolean) => {
+    store.update((state) => {
+      state.removeParensFromTitle = value;
+      return state;
+    });
+  };
+
+  const setRemoveParensFromAuthor = (value: boolean) => {
+    store.update((state) => {
+      state.removeParensFromAuthor = value;
+      return state;
+    });
+  };
+
   return {
     store,
     subscribe: store.subscribe,
@@ -189,6 +225,10 @@ const createSettingsStore = () => {
       setIgnoredBooks,
       setRemoveParens,
       setRemoveParensWhitelist,
+      setRemoveParensType,
+      setRemoveParensSpaces,
+      setRemoveParensFromTitle,
+      setRemoveParensFromAuthor,
     },
   };
 };

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -20,9 +20,6 @@ type Settings = {
   removeParens: boolean;
   removeParensWhitelist: string;
   removeParensType: 'all' | 'chinese' | 'english';
-  removeParensSpaces: boolean;
-  removeParensFromTitle: boolean;
-  removeParensFromAuthor: boolean;
 
   // Deprecated - delete eventually
   noteTemplate?: string;
@@ -41,9 +38,6 @@ const DEFAULT_SETTINGS: Settings = {
   removeParens: false,
   removeParensWhitelist: '',
   removeParensType: 'all',
-  removeParensSpaces: true,
-  removeParensFromTitle: true,
-  removeParensFromAuthor: false,
 };
 
 const createSettingsStore = () => {
@@ -187,27 +181,6 @@ const createSettingsStore = () => {
     });
   };
 
-  const setRemoveParensSpaces = (value: boolean) => {
-    store.update((state) => {
-      state.removeParensSpaces = value;
-      return state;
-    });
-  };
-
-  const setRemoveParensFromTitle = (value: boolean) => {
-    store.update((state) => {
-      state.removeParensFromTitle = value;
-      return state;
-    });
-  };
-
-  const setRemoveParensFromAuthor = (value: boolean) => {
-    store.update((state) => {
-      state.removeParensFromAuthor = value;
-      return state;
-    });
-  };
-
   return {
     store,
     subscribe: store.subscribe,
@@ -226,9 +199,6 @@ const createSettingsStore = () => {
       setRemoveParens,
       setRemoveParensWhitelist,
       setRemoveParensType,
-      setRemoveParensSpaces,
-      setRemoveParensFromTitle,
-      setRemoveParensFromAuthor,
     },
   };
 };

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -17,6 +17,8 @@ type Settings = {
   syncOnBoot: boolean;
   downloadBookMetadata: boolean;
   ignoredBooks: string[];
+  removeParens: boolean;
+  removeParensWhitelist: string;
 
   // Deprecated - delete eventually
   noteTemplate?: string;
@@ -32,6 +34,8 @@ const DEFAULT_SETTINGS: Settings = {
   syncOnBoot: false,
   downloadBookMetadata: true,
   ignoredBooks: [],
+  removeParens: false,
+  removeParensWhitelist: '',
 };
 
 const createSettingsStore = () => {
@@ -154,6 +158,20 @@ const createSettingsStore = () => {
     });
   };
 
+  const setRemoveParens = (value: boolean) => {
+    store.update((state) => {
+      state.removeParens = value;
+      return state;
+    });
+  };
+
+  const setRemoveParensWhitelist = (value: string) => {
+    store.update((state) => {
+      state.removeParensWhitelist = value;
+      return state;
+    });
+  };
+
   return {
     store,
     subscribe: store.subscribe,
@@ -169,6 +187,8 @@ const createSettingsStore = () => {
       setDownloadBookMetadata,
       setAmazonRegion,
       setIgnoredBooks,
+      setRemoveParens,
+      setRemoveParensWhitelist,
     },
   };
 };

--- a/styles.css
+++ b/styles.css
@@ -30,13 +30,13 @@
   }
 }
 
-.parentheses-settings {
+.bracket-settings {
   margin: 0.5em 0 1em 0;
   padding: 0 0 0 1em;
   border-left: 2px solid var(--background-modifier-border);
 }
 
-.parentheses-settings summary {
+.bracket-settings summary {
   cursor: pointer;
   color: var(--text-muted);
   font-size: 0.9em;

--- a/styles.css
+++ b/styles.css
@@ -29,21 +29,3 @@
     );
   }
 }
-
-.bracket-settings {
-  margin: 0.5em 0 1em 0;
-  padding: 0 0 0 1em;
-  border-left: 2px solid var(--background-modifier-border);
-}
-
-.bracket-settings summary {
-  cursor: pointer;
-  color: var(--text-muted);
-  font-size: 0.9em;
-  padding: 0.3em 0;
-  user-select: none;
-}
-
-.bracket-settings summary:hover {
-  color: var(--text-normal);
-}

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,7 @@
       0 0 8px color-mix(in srgb, var(--interactive-accent) 55%, transparent)
     );
   }
+
   50% {
     opacity: 0.65;
     box-shadow: 0 0 0 6px color-mix(in srgb, var(--interactive-accent) 0%, transparent);
@@ -29,13 +30,13 @@
   }
 }
 
-.bracket-settings {
+.parentheses-settings {
   margin: 0.5em 0 1em 0;
   padding: 0 0 0 1em;
   border-left: 2px solid var(--background-modifier-border);
 }
 
-.bracket-settings summary {
+.parentheses-settings summary {
   cursor: pointer;
   color: var(--text-muted);
   font-size: 0.9em;

--- a/styles.css
+++ b/styles.css
@@ -28,3 +28,21 @@
     );
   }
 }
+
+.bracket-settings {
+  margin: 0.5em 0 1em 0;
+  padding: 0 0 0 1em;
+  border-left: 2px solid var(--background-modifier-border);
+}
+
+.bracket-settings summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 0.9em;
+  padding: 0.3em 0;
+  user-select: none;
+}
+
+.bracket-settings summary:hover {
+  color: var(--text-normal);
+}


### PR DESCRIPTION
Many book titles in the Chinese Kindle library include parenthetical notes, and these parenthetical contents are written verbatim into Obsidian note filenames, resulting in excessively long filenames or filenames containing meaningless annotations. This feature allows users to automatically remove parentheses and their contents when generating filenames.

Add automatic bracket removal from book titles and author names
when generating file names. At the same time, a setting has been added to allow fine-grained control over whether to enable this feature.

Features:
- Remove Chinese full-width brackets and/or English brackets
- Per-field control (title and author independently)
- Bracket type selection (All / Chinese only / English only)
- Optional space cleanup around English brackets
- Whitelist keywords to skip removal
- Collapsible settings section for bracket removal options
- Disabled by default, user opt-in required

<img width="730" height="618" alt="image" src="https://github.com/user-attachments/assets/0ce02b1f-1986-47d4-a50b-9810d3864d3c" />
