### PR TITLE
fix: keep Amazon login inside the plugin window

### DIFF
--- a/src/components/amazonLoginModal/index.ts
+++ b/src/components/amazonLoginModal/index.ts
@@ -30,6 +30,10 @@ export default class AmazonLoginModal {
       show: false,
     });
 
+    // Obsidian cancels http(s) navigations in every window it creates and reopens them in the
+    // system browser, ejecting the Amazon login flow. Drop that listener on the window we own.
+    this.modal.webContents.removeAllListeners('will-navigate');
+
     // We can only change title after page is loaded since HTML page has its own title
     this.modal.once('ready-to-show', () => {
       this.modal.setTitle('Connect your Amazon account to Obsidian');


### PR DESCRIPTION
## Problem

Amazon Cloud sync never completes on current Obsidian. The login window opens, but as soon as you enter your email and click Continue, the flow is ejected into your default system browser. Logging in there does nothing for the plugin, and the sync modal sits on "Logging in…" forever.

## Cause

Obsidian's main process hardens every `webContents` the app creates including `BrowserWindow`s opened by plugins with a `will-navigate` listener that cancels http(s) navigations and hands the URL to `shell.openExternal`. The login then completes in the browser's cookie jar rather than the plugin's `persist:kindle-highlights` partition, so `did-navigate` never reaches `kindleReaderUrl` and the promise returned by `doLogin()` never resolves.

## Fix

Fix #337

Drop that listener from the window the plugin owns:

```ts
this.modal.webContents.removeAllListeners('will-navigate');
```

Obsidian registers it once, at `web-contents-created`, guarded by an `isSecured` flag, so removing it immediately after construction is sufficient and nothing re-adds it. The plugin is the only owner of this window, and it only ever loads Amazon sign-in URLs.

## Verification

Tested end to end on Obsidian 1.13.4 / Electron 28.2.3 / macOS 15, with two-factor authentication enabled. The full chain now stays inside the plugin window:

## Note on Passkey Incompatibility

Amazon's sign-in page throws `TypeError: u.PublicKeyCredential.getClientCapabilities is not a function` from `AUIClients/IdentityWebAuthnAssets`. Electron 28 ships Chrome 120, which predates that API. It does not block password or OTP sign-in, but an account configured for passkey-only auth likely cannot complete login in this window at all.

Thank you for this plugin, it's a great win for my Obsidian notes!
