### PR TITLE
fix: stop duplicate highlight files on sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/faker": "^5.5.9",
     "@types/jest": "^26.0.24",
     "@types/lodash": "^4.17.21",
+    "@types/node": "^20.11.0",
     "@types/nunjucks": "^3.2.6",
     "@types/webpack": "^5.28.5",
     "@typescript-eslint/eslint-plugin": "^4.33.0",

--- a/src/fileManager/index.ts
+++ b/src/fileManager/index.ts
@@ -11,6 +11,40 @@ import { bookFilePath, bookToFrontMatter, frontMatterToBook } from './mappers';
 const SyncingStateKey = 'kindle-sync';
 const PropertyPrefix = 'kindle-';
 
+/**
+ * Normalize a raw frontmatter object (from either the metadata cache or a
+ * direct file read) into KindleFrontmatter, supporting both the legacy nested
+ * `kindle-sync:` format and the current flat `kindle-*` properties format.
+ */
+const toKindleFrontmatter = (frontmatter: unknown): KindleFrontmatter | undefined => {
+  if (frontmatter == null) {
+    return undefined;
+  }
+
+  const properties = frontmatter as Record<string, unknown>;
+
+  // Try nested format first (legacy support)
+  const nested = properties[SyncingStateKey] as KindleFrontmatter | undefined;
+  if (nested != null) {
+    return nested;
+  }
+
+  // If not found, try flat format (new Obsidian properties format)
+  if (properties[`${PropertyPrefix}bookId`] != null) {
+    return {
+      bookId: properties[`${PropertyPrefix}bookId`] as string,
+      title: properties[`${PropertyPrefix}title`] as string,
+      author: properties[`${PropertyPrefix}author`] as string,
+      asin: properties[`${PropertyPrefix}asin`] as string | undefined,
+      lastAnnotatedDate: properties[`${PropertyPrefix}lastAnnotatedDate`] as string | undefined,
+      bookImageUrl: properties[`${PropertyPrefix}bookImageUrl`] as string | undefined,
+      highlightsCount: properties[`${PropertyPrefix}highlightsCount`] as number | undefined,
+    };
+  }
+
+  return undefined;
+};
+
 export default class FileManager {
   constructor(private vault: Vault, private metadataCache: MetadataCache) {}
 
@@ -18,10 +52,19 @@ export default class FileManager {
     return await this.vault.cachedRead(file.file);
   }
 
-  public getKindleFile(book: Book): KindleFile | undefined {
-    const allSyncedFiles = this.getKindleFiles();
+  public async getKindleFile(book: Book): Promise<KindleFile | undefined> {
+    const allSyncedFiles = await this.getKindleFilesAsync();
 
-    const kindleFile = allSyncedFiles.find((file) => file.frontmatter.bookId === book.id);
+    // Primary match: stable title hash (backwards compatible; only option when
+    // ASIN is absent, e.g. "My Clippings" uploads).
+    const kindleFile =
+      allSyncedFiles.find((file) => file.frontmatter.bookId === book.id) ??
+      // Fallback match: ASIN is stable even when Amazon changes a book's title
+      // (subtitle / edition / author-credential drift), which otherwise changes
+      // the title hash and makes the existing file miss -> duplicate.
+      (book.asin != null
+        ? allSyncedFiles.find((file) => file.frontmatter.asin === book.asin)
+        : undefined);
 
     return kindleFile == null ? undefined : { ...kindleFile, book };
   }
@@ -42,26 +85,7 @@ export default class FileManager {
       const fileCache = this.metadataCache.getFileCache(file);
 
       // File cache can be undefined if this file was just created and not yet cached by Obsidian
-      // Try both nested format (legacy) and flat format (new)
-      let kindleFrontmatter: KindleFrontmatter | undefined;
-      
-      if (fileCache?.frontmatter) {
-        // Try nested format first (legacy support)
-        kindleFrontmatter = fileCache.frontmatter[SyncingStateKey] as KindleFrontmatter | undefined;
-        
-        // If not found, try flat format (new Obsidian properties format)
-        if (!kindleFrontmatter && fileCache.frontmatter[`${PropertyPrefix}bookId`]) {
-          kindleFrontmatter = {
-            bookId: fileCache.frontmatter[`${PropertyPrefix}bookId`] as string,
-            title: fileCache.frontmatter[`${PropertyPrefix}title`] as string,
-            author: fileCache.frontmatter[`${PropertyPrefix}author`] as string,
-            asin: fileCache.frontmatter[`${PropertyPrefix}asin`] as string | undefined,
-            lastAnnotatedDate: fileCache.frontmatter[`${PropertyPrefix}lastAnnotatedDate`] as string | undefined,
-            bookImageUrl: fileCache.frontmatter[`${PropertyPrefix}bookImageUrl`] as string | undefined,
-            highlightsCount: fileCache.frontmatter[`${PropertyPrefix}highlightsCount`] as number | undefined,
-          };
-        }
-      }
+      const kindleFrontmatter = toKindleFrontmatter(fileCache?.frontmatter);
 
       if (kindleFrontmatter == null) {
         return undefined;
@@ -77,6 +101,67 @@ export default class FileManager {
   }
 
   public getKindleFiles(): KindleFile[] {
+    if (!this.metadataCache) {
+      return [];
+    }
+
+    const filesToProcess = this.getFilesInHighlightsFolder().slice(0, 1000);
+
+    return filesToProcess
+      .map((file) => {
+        try {
+          return this.mapToKindleFile(file);
+        } catch (error) {
+          // Silently skip files that can't be parsed to prevent blocking
+          return undefined;
+        }
+      })
+      .filter((file) => file != null) ;
+  }
+
+  /**
+   * Same as getKindleFiles but resilient to a stale/missing metadata cache:
+   * files whose frontmatter isn't in the cache are read directly from disk so
+   * they are not silently dropped from the sync list (which would cause the
+   * book to be re-created as a duplicate).
+   */
+  public async getKindleFilesAsync(): Promise<KindleFile[]> {
+    const filesToProcess = this.getFilesInHighlightsFolder().slice(0, 1000);
+
+    if (filesToProcess.length === 0) {
+      return [];
+    }
+
+    const kindleFiles: KindleFile[] = [];
+    for (const file of filesToProcess) {
+      try {
+        const cached = this.mapToKindleFile(file);
+        if (cached != null) {
+          kindleFiles.push(cached);
+          continue;
+        }
+
+        // Cache miss: read the frontmatter directly from the file content.
+        const raw = await this.vault.cachedRead(file);
+        const { data } = matter(raw);
+        const kindleFrontmatter = toKindleFrontmatter(data);
+        if (kindleFrontmatter == null) {
+          continue;
+        }
+        kindleFiles.push({
+          file,
+          frontmatter: kindleFrontmatter,
+          book: frontMatterToBook(kindleFrontmatter),
+        });
+      } catch (error) {
+        // Silently skip files that can't be parsed to prevent blocking
+      }
+    }
+
+    return kindleFiles;
+  }
+
+  private getFilesInHighlightsFolder(): TFile[] {
     try {
       // Safety check: if settings store isn't ready, return empty array
       // This prevents blocking during plugin initialization
@@ -88,17 +173,17 @@ export default class FileManager {
         console.warn('Settings store not ready, skipping file scan');
         return [];
       }
-      
+
       // Safety check: if vault isn't ready, return empty array
-      if (!this.vault || !this.metadataCache) {
+      if (!this.vault) {
         return [];
       }
-      
+
       // Get files directly from the highlights folder if possible
       const folderPath = normalizePath(highlightsFolder === '/' ? '' : highlightsFolder);
-      
+
       let filesInFolder: TFile[] = [];
-      
+
       try {
         // Try to get the folder directly and its files
         if (folderPath !== '') {
@@ -149,27 +234,8 @@ export default class FileManager {
           return [];
         }
       }
-      
-      // If no files, return early
-      if (filesInFolder.length === 0) {
-        return [];
-      }
-      
-      // Limit the number of files we process to prevent blocking
-      // Process files in smaller batches
-      const maxFilesToProcess = 1000;
-      const filesToProcess = filesInFolder.slice(0, maxFilesToProcess);
-      
-      return filesToProcess
-        .map((file) => {
-          try {
-            return this.mapToKindleFile(file);
-          } catch (error) {
-            // Silently skip files that can't be parsed to prevent blocking
-            return undefined;
-          }
-        })
-        .filter((file) => file != null) ;
+
+      return filesInFolder;
     } catch (error) {
       console.error('Error getting Kindle files:', error);
       return [];

--- a/src/sync/syncAmazon/index.ts
+++ b/src/sync/syncAmazon/index.ts
@@ -39,7 +39,7 @@ export default class SyncAmazon {
         return;
       }
 
-      const booksToSync = this.syncManager.filterBooksToSync(remoteBooks);
+      const booksToSync = await this.syncManager.filterBooksToSync(remoteBooks);
       syncCancellation.setTotalCount(booksToSync.length);
 
       ee.emit('fetchingBooksSuccess', booksToSync, remoteBooks);

--- a/src/sync/syncManager/diffBooks.spec.ts
+++ b/src/sync/syncManager/diffBooks.spec.ts
@@ -64,4 +64,20 @@ describe('diffBooks', () => {
     const actualBooks = diffBooks(remoteBooks, vaultBooks, new Date());
     expect(actualBooks.map((a) => a.id)).toEqual(['1']);
   });
+
+  it('Books with matching ASIN are not treated as new even when the id differs', () => {
+    const remoteBooks = [{ ...book('new-id'), asin: 'B0000ASIN1' }];
+    const vaultBooks = [{ ...book('old-id'), asin: 'B0000ASIN1' }];
+
+    const actualBooks = diffBooks(remoteBooks, vaultBooks, new Date());
+    expect(actualBooks).toHaveLength(0);
+  });
+
+  it('Books with no ASIN are still matched by id alone', () => {
+    const remoteBooks = [book('1')];
+    const vaultBooks = [book('2')];
+
+    const actualBooks = diffBooks(remoteBooks, vaultBooks, new Date());
+    expect(actualBooks.map((a) => a.id)).toEqual(['1']);
+  });
 });

--- a/src/sync/syncManager/diffBooks.ts
+++ b/src/sync/syncManager/diffBooks.ts
@@ -4,7 +4,10 @@ import moment from 'moment';
 import type { Book } from '~/models';
 
 const isEqual = (book1: Book, book2: Book): boolean => {
-  return book1.id === book2.id;
+  // Match on the title-hash id, but fall back to ASIN: the id changes when
+  // Amazon alters a book's title, whereas ASIN is stable. Without the fallback
+  // a title drift makes the existing file miss and the book is re-created.
+  return book1.id === book2.id || (book1.asin != null && book1.asin === book2.asin);
 };
 
 const isSameDate = (date1: Date | undefined, date2: Date | undefined): boolean => {

--- a/src/sync/syncManager/index.ts
+++ b/src/sync/syncManager/index.ts
@@ -16,10 +16,10 @@ export default class SyncManager {
     this.fileManager = fileManager;
   }
 
-  public filterBooksToSync(remoteBooks: Book[]): Book[] {
+  public async filterBooksToSync(remoteBooks: Book[]): Promise<Book[]> {
     const lastSyncDate = get(settingsStore).lastSyncDate;
     const ignoredBooks = get(settingsStore).ignoredBooks ?? [];
-    const vaultBooks = this.fileManager.getKindleFiles();
+    const vaultBooks = await this.fileManager.getKindleFilesAsync();
 
     const booksToSync = diffBooks(
       remoteBooks,
@@ -43,7 +43,7 @@ export default class SyncManager {
       return; // No highlights for book. Skip sync
     }
 
-    const file = this.fileManager.getKindleFile(book);
+    const file = await this.fileManager.getKindleFile(book);
 
     if (file == null) {
       await this.createBook(book, highlights);


### PR DESCRIPTION
Fixes #334.

## Problem

Syncing periodically re-creates a book's highlight file as a duplicate with a `Date.now()` suffix appended to the filename. `SyncManager.syncBook` decides create-vs-resync via `FileManager.getKindleFile`, which matched existing files **only** on `book.id` — a 16-bit Fletcher-16 checksum of the lower-cased title (`src/utils/hash.ts`). When that lookup misses, `syncBook` falls back to `createBook`, and `generateUniqueFilePath` appends a timestamp to the already-taken filename.

Two independent causes make the lookup miss:

1. **Title drift / hash collision.** Any Amazon-side title change (edition subtitle like `(One World Essentials)`, subtitle, or author credential like `LICSW Resmaa Menakem, MSW`) changes the hash, so the existing file's `kindle-bookId` no longer matches. A 16-bit hash is also collision-prone.
2. **Metadata-cache miss.** `getKindleFiles()` built its list via `metadataCache.getFileCache()`, which returns `null`/stale for files created or modified outside Obsidian (external sync, scripts). The existing file silently dropped out of the list, so *neither* the id *nor* an ASIN lookup could find it.

## Fix

- **ASIN fallback** — `getKindleFile` and `diffBooks.isEqual` now fall back to matching on the stable `asin` field when the title hash doesn't match.
- **Frontmatter from content** — a new async `getKindleFilesAsync()` reads a file's frontmatter directly from disk (`vault.cachedRead` + gray-matter) when the metadata cache misses, so cache-missed files are no longer dropped from the sync list. `getKindleFile` and `filterBooksToSync` are now async and use it; the sync path awaits them. The sync `getKindleFiles()` is unchanged and still backs the display-only callers (settings count, status bar, file menu).

Both changes are additive fallbacks and cannot regress books that already match by id.

## Verification

- `npx tsc --noemit`: 0 errors in `src/` (only pre-existing `@types/node`/`ffi.d.ts` parse errors remain under TS 4.9).
- `npm run test`: 147 passing (added 2 cases for the ASIN fallback in `diffBooks`).
- `npx webpack` (production): compiles cleanly.
